### PR TITLE
NO JIRA. Point to API (temporary)

### DIFF
--- a/webpack/config.json
+++ b/webpack/config.json
@@ -3,6 +3,6 @@
     "apiHost": "http://localhost:3004"
   },
   "production": {
-    "apiHost": ""
+    "apiHost": "http://deasy.dans.knaw.nl/deposit-api"
   }
 }


### PR DESCRIPTION
Temporarily changed the apiHost setting for production to http://deasy.dans.knaw.nl/deposit-api. The final solution should probably be to find out the name of the host that sent the Javascript dynamically (?). Otherwise we would need separated rpms for dev, test, act and prod.

