### PR TITLE
NO-EASY: Send authentication as params

### DIFF
--- a/src/main/typescript/actions/authenticationActions.ts
+++ b/src/main/typescript/actions/authenticationActions.ts
@@ -21,13 +21,10 @@ import axios from "axios"
 export const authenticate: (userName: string, password: string) => ReduxAction<Promise<void>> = (userName, password) => ({
     type: AuthenticationConstants.AUTH_LOGIN,
     async payload() {
-        await new Promise(vs => {
-                setTimeout(vs, 1000)
-            },
-        )
-
-        // TODO temporary do a timeout to simulate server I/O
-        await axios.post(loginURL, {}, { auth: { username: userName, password: password } })
+        const params = new URLSearchParams()
+        params.append('login', userName)
+        params.append('password',password)
+        await axios.post(loginURL, params)
     },
 })
 

--- a/src/main/typescript/components/Header.tsx
+++ b/src/main/typescript/components/Header.tsx
@@ -103,7 +103,7 @@ class Header extends Component<HeaderProps> {
             ? [
                 <span key="loginName" className="navbar-text">{loginName}</span>,
                 <NavBarLink key="my datasets" to={depositOverviewRoute}>My Datasets</NavBarLink>,
-                <Link onClick={signout} className="nav-link logoff" key="log out" to="/" title="Log out">Log out</Link>,
+                <Link onClick={signout} className="nav-link logoff" key="log out" to={homeRoute} title="Log out">Log out</Link>,
             ]
             : [<NavBarLink key="login" to={loginRoute} title="Login to EASY">Login</NavBarLink>]
 

--- a/src/main/typescript/constants/clientRoutes.ts
+++ b/src/main/typescript/constants/clientRoutes.ts
@@ -15,8 +15,8 @@
  */
 import { DepositId } from "../model/Deposits"
 
-export const homeRoute = "/"
-export const registerRoute = "/register" // this route doesn't exist, but to be complete, I add it here as well
-export const loginRoute = "/login"
-export const depositFormRoute = (id: DepositId) => `/deposit-form/${id}`
-export const depositOverviewRoute = "/deposit-overview"
+export const homeRoute = "/deposit"
+export const registerRoute = `${homeRoute}/register` // this route doesn't exist, but to be complete, I add it here as well
+export const loginRoute = `${homeRoute}/login`
+export const depositFormRoute = (id: DepositId) => `${homeRoute}/deposit-form/${id}`
+export const depositOverviewRoute = `${homeRoute}/deposit-overview`

--- a/src/main/typescript/middleware/userDetailsMiddleware.ts
+++ b/src/main/typescript/middleware/userDetailsMiddleware.ts
@@ -34,7 +34,7 @@ const userFetchConverter: Middleware = createMiddleware(({ dispatch }, next, act
                 prefix: action.payload.prefix,
                 lastName: action.payload.lastName,
                 groups: action.payload.groups,
-                displayName: action.payload.firstName + " " + action.payload.prefix + " " + action.payload.lastName,
+                displayName: `${action.payload.firstName} ${action.payload.prefix ? action.payload.prefix+" " : ""}${action.payload.lastName}`,
             }
 
             dispatch(fetchUserSucceeded(user))

--- a/src/main/typescript/reducers/authenticationReducer.ts
+++ b/src/main/typescript/reducers/authenticationReducer.ts
@@ -20,7 +20,7 @@ import { AuthenticationConstants } from "../constants/authenticationConstants"
 export const authenticationReducer: Reducer<Authentication> = (state = empty, action) => {
     switch (action.type) {
         case AuthenticationConstants.AUTH_LOGIN_FULFILLED: {
-            return { ...state, isAuthenticated: true, isAuthenticating:false }
+            return { ...state, isAuthenticated: true, isAuthenticating:false, authenticationError: "" }
         }
         case AuthenticationConstants.AUTH_LOGIN_PENDING: {
             return { ...state, isAuthenticated: false, isAuthenticating: true }
@@ -29,7 +29,7 @@ export const authenticationReducer: Reducer<Authentication> = (state = empty, ac
             return { ...state, isAuthenticated: false, authenticationError: action.payload, isAuthenticating: false }
         }
         case AuthenticationConstants.AUTH_LOGOUT_FULFILLED: {
-            return { ...state, isAuthenticated: false }
+            return { ...state, isAuthenticated: false, authenticationError: "" }
         }
         default:
             return state

--- a/src/test/typescript/mockserver/user.ts
+++ b/src/test/typescript/mockserver/user.ts
@@ -16,7 +16,7 @@
 export interface User {
     username: string
     firstName: string
-    prefix: string
+    prefix?: string
     lastName: string
     groups: string[]
 }
@@ -24,7 +24,7 @@ export interface User {
 export const User001: User = {
     username: "user001",
     firstName: "First",
-    prefix: "van",
+    prefix: undefined,
     lastName: "Namen",
     groups: [ "group001", "group002"]
 }

--- a/webpack/config.json
+++ b/webpack/config.json
@@ -3,6 +3,6 @@
     "apiHost": "http://localhost:3004"
   },
   "production": {
-    "apiHost": ""
+    "apiHost": "/deposit-api"
   }
 }


### PR DESCRIPTION

#### When applied it will
* Send authentication as params
* Use 'deposit' as homeRoute
* Use 'deposit-api' as api path

#### Where should the reviewer @DANS-KNAW/easy start?

