### PR TITLE
use compose when using multiple HOCs

### DIFF
--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -15,10 +15,12 @@
  */
 import * as React from "react"
 import { Component, SFC } from "react"
+import { compose } from "redux"
+import { connect } from "react-redux"
+import { InjectedFormProps, reduxForm } from "redux-form"
 import Card from "./FoldableCard"
 import "../../../resources/css/depositForm.css"
 import "../../../resources/css/form.css"
-import { InjectedFormProps, reduxForm } from "redux-form"
 import {
     ArchaeologySpecificMetadata,
     BasicInformation,
@@ -35,7 +37,6 @@ import { DepositId } from "../../model/Deposits"
 import { ReduxAction } from "../../lib/redux"
 import { fetchMetadata, saveDraft, submitDeposit } from "../../actions/depositFormActions"
 import { AppState } from "../../model/AppState"
-import { connect } from "react-redux"
 import { DepositFormState } from "../../model/DepositForm"
 import { Alert, ReloadAlert } from "../../Errors"
 
@@ -97,8 +98,8 @@ interface DepositFormStoreArguments {
     formState: DepositFormState
     formValues?: DepositFormData,
     fetchMetadata: (depositId: DepositId) => ReduxAction<Promise<any>>
-    saveDraft: (depositId: DepositId, data: DepositFormData) => ReduxAction<{depositId: DepositId, data: DepositFormData}>
-    submitDeposit: (depositId: DepositId, data: DepositFormData) => ReduxAction<{depositId: DepositId, data: DepositFormData}>,
+    saveDraft: (depositId: DepositId, data: DepositFormData) => ReduxAction<{ depositId: DepositId, data: DepositFormData }>
+    submitDeposit: (depositId: DepositId, data: DepositFormData) => ReduxAction<{ depositId: DepositId, data: DepositFormData }>,
 }
 
 type DepositFormProps = DepositFormStoreArguments & InjectedFormProps<DepositFormData, DepositFormStoreArguments>
@@ -212,8 +213,6 @@ class DepositForm extends Component<DepositFormProps> {
     }
 }
 
-const depositForm = reduxForm<DepositFormData>({ form: "depositForm", enableReinitialize: true })(DepositForm)
-
 const mapStateToProps = (state: AppState) => ({
     depositId: state.depositForm.depositId,
     formState: state.depositForm,
@@ -221,8 +220,9 @@ const mapStateToProps = (state: AppState) => ({
     formValues: state.form.depositForm && state.form.depositForm.values,
 })
 
-export default connect<{}>(mapStateToProps, {
-    fetchMetadata,
-    saveDraft,
-    submitDeposit,
-})(depositForm)
+const composedHOC = compose(
+    connect(mapStateToProps, { fetchMetadata, saveDraft, submitDeposit }),
+    reduxForm({ form: "depositForm", enableReinitialize: true }),
+)
+
+export default composedHOC(DepositForm)

--- a/src/main/typescript/components/login/LoginPage.tsx
+++ b/src/main/typescript/components/login/LoginPage.tsx
@@ -15,13 +15,14 @@
  */
 import * as React from "react"
 import { Component } from "react"
-import { ReduxAction } from "../../lib/redux"
-import { connect } from "react-redux"
-import { authenticate } from "../../actions/authenticationActions"
 import { Redirect, RouteComponentProps } from "react-router"
+import { compose } from "redux"
+import { connect } from "react-redux"
+import { InjectedFormProps, reduxForm, Field } from "redux-form"
+import { ReduxAction } from "../../lib/redux"
+import { authenticate } from "../../actions/authenticationActions"
 import { AppState } from "../../model/AppState"
 import { homeRoute } from "../../constants/clientRoutes"
-import { InjectedFormProps, reduxForm, Field } from "redux-form"
 
 interface LoginPageProps {
     authenticate: (username: string, password: string) => ReduxAction<Promise<any>>
@@ -47,8 +48,8 @@ class LoginPage extends Component<AllDemoFormProps> {
     }
 
     render() {
-        const {authenticated, errorMessage, location, handleSubmit} = this.props
-        const {from} = location.state || {from: {pathname: homeRoute}}
+        const { authenticated, errorMessage, location, handleSubmit } = this.props
+        const { from } = location.state || { from: { pathname: homeRoute } }
 
         return authenticated
             ? <Redirect to={from}/>
@@ -62,7 +63,7 @@ class LoginPage extends Component<AllDemoFormProps> {
                 <br/>
 
                 <button type="submit" disabled={this.props.authenticating}>Login</button>
-                {errorMessage  && <span>{errorMessage.message}<br/></span>}
+                {errorMessage && <span>{errorMessage.message}<br/></span>}
             </form>
     }
 }
@@ -73,5 +74,9 @@ const mapStateToProps = (state: AppState) => ({
     errorMessage: state.authenticatedUser.authenticationError,
 })
 
-const form = reduxForm<LoginPageData>({form: 'login'})(LoginPage)
-export default connect<{}>(mapStateToProps, {authenticate})(form)
+const composedHOC = compose(
+    connect(mapStateToProps, { authenticate }),
+    reduxForm<LoginPageData>({ form: "login" }),
+)
+
+export default composedHOC(LoginPage)


### PR DESCRIPTION
rather than doing manual composition of HOCs (and with that do some magic with types), I found we can also use the `compose` function. Note that the order of the arguments is important, they are applied _**right to left**_.

@DANS-KNAW/easy for review