### PR TITLE
Introducing unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ install:
   - npm install
 
 script:
+  - npm run test
   - npm run build
   - mvn clean install

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,12 @@
         "@types/node": "9.6.1"
       }
     },
+    "@types/chai": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.3.tgz",
+      "integrity": "sha512-f5dXGzOJycyzSMdaXVhiBhauL4dYydXwVpavfQ1mVCaGjR56a9QfklXObUxlIY9bGTmCPHEEZ04I16BZ/8w5ww==",
+      "dev": true
+    },
     "@types/cors": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.3.tgz",
@@ -72,6 +78,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
       "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-YeDiSEzznwZwwp766SJ6QlrTyBYUGPSIwmREHVTmktUYiT/WADdWtpt9iH0KuUSf8lZLdI4lP0X6PBzPo5//JQ==",
       "dev": true
     },
     "@types/node": {
@@ -402,6 +414,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -426,6 +444,12 @@
       "requires": {
         "util": "0.10.3"
       }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -854,6 +878,12 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browserify-aes": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
@@ -1107,6 +1137,20 @@
         "lazy-cache": "1.0.4"
       }
     },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
     "chalk": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
@@ -1117,6 +1161,12 @@
         "escape-string-regexp": "1.0.5",
         "supports-color": "5.3.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "2.0.3",
@@ -1982,6 +2032,15 @@
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
       "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -2053,6 +2112,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "diffie-hellman": {
@@ -3924,6 +3989,12 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -4054,6 +4125,12 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "handle-thing": {
@@ -5104,6 +5181,12 @@
         "pify": "3.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+      "dev": true
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -5435,6 +5518,36 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "monocle-ts": {
@@ -6064,6 +6177,12 @@
           "dev": true
         }
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.14",
@@ -9756,10 +9875,40 @@
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
+    "ts-node": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.0.5.tgz",
+      "integrity": "sha512-iNhWu2hli9/1p9PGLJ/4OZS+NR0IVEVk63KCrH3qa7jJZxXa+oPheBj5JyM8tuQM9RkBpw1PrNUEUPJR9wTGDw==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "2.3.2",
+        "diff": "3.5.0",
+        "make-error": "1.3.4",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.4",
+        "yn": "2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-is": {
@@ -10685,6 +10834,12 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "NODE_ENV=development webpack-dev-server --hot --open --config webpack/dev.config.js",
     "build": "NODE_ENV=production webpack --config webpack/prod.config.js",
+    "test": "mocha -r ts-node/register src/test/typescript/**/*.spec.ts",
     "mockserver": "webpack --config webpack/mockserver.config.js && node target/build-mockserver/server.js"
   },
   "repository": {
@@ -43,11 +44,13 @@
     "uuid": "^3.2.1"
   },
   "devDependencies": {
+    "@types/chai": "^4.1.3",
     "@types/cors": "^2.8.3",
     "@types/dateformat": "^1.0.1",
     "@types/express": "^4.11.1",
     "@types/history": "^4.6.2",
     "@types/lodash": "^4.14.106",
+    "@types/mocha": "^5.2.0",
     "@types/query-string": "^5.1.0",
     "@types/react": "^16.0.40",
     "@types/react-dom": "^16.0.4",
@@ -66,6 +69,7 @@
     "awesome-typescript-loader": "^3.5.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "chai": "^4.1.2",
     "clean-webpack-plugin": "^0.1.18",
     "cors": "^2.8.4",
     "css-hot-loader": "^1.3.9",
@@ -75,11 +79,13 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.11",
     "html-webpack-plugin": "^2.30.1",
+    "mocha": "^5.2.0",
     "postcss-loader": "^2.1.1",
     "react-hot-loader": "^3.1.3",
     "redux-devtools-extension": "^2.13.2",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.20.2",
+    "ts-node": "^6.0.5",
     "typescript": "^2.7.2",
     "uglifyjs-webpack-plugin": "^1.2.2",
     "webpack": "^3.11.0",

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dans-provider-name>dans.knaw.nl</dans-provider-name>
         <context-root>deposit</context-root>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.test.skip>false</maven.test.skip>
+        <skipTests>false</skipTests>
         <output.directory>target/build</output.directory>
         <dans-build-resources.version>2.4.0</dans-build-resources.version>
     </properties>
@@ -104,27 +104,23 @@
                         </configuration>
                     </execution>
 
-                    <!-- Run unit tests. My test scripts in npm look for the property 'skipTests',
-                         so I map it to 'maven.test.skip'
-                         Note: the double '-' syntax used below only works with npm >= 2. -->
-                    <!-- TODO uncomment the execution once we have tests defined in our project
-                         and 'npm run test' is defined in package.json -->
-                    <!--<execution>
+                    <!-- Run unit tests using `npm run test` where 'test' is the script name
+                         we defined in package.json -->
+                    <execution>
                         <id>npm run test (test)</id>
                         <goals>
                             <goal>exec</goal>
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <executable>npm</executable>
                             <arguments>
                                 <argument>run</argument>
                                 <argument>test</argument>
-                                <argument>&#45;&#45;</argument>
-                                <argument>&#45;&#45;skipTests=${maven.test.skip}</argument>
                             </arguments>
                         </configuration>
-                    </execution>-->
+                    </execution>
                 </executions>
             </plugin>
 

--- a/src/main/typescript/lib/metadata/AccessRight.ts
+++ b/src/main/typescript/lib/metadata/AccessRight.ts
@@ -54,7 +54,7 @@ export const accessRightConverter: (ar: any) => AccessRight = ar => {
 
         }
     else
-        throw `Error in metadata: no such access right: '${ar.category}'`
+        throw `Error in metadata: no such access category: '${ar.category}'`
 }
 
 export const accessRightDeconverter: (ar: AccessRight) => any = ar => clean({

--- a/src/main/typescript/lib/metadata/AccessRight.ts
+++ b/src/main/typescript/lib/metadata/AccessRight.ts
@@ -28,21 +28,33 @@ export enum AccessRightValue {
     NO_ACCESS = "NO_ACCESS",
 }
 
-export function toAccessRight(value: string): AccessRightValue | undefined {
+function toAccessRight(value: string): AccessRightValue | undefined {
     return Object.values(AccessRightValue).find(v => v === value)
 }
 
 export const accessRightConverter: (ar: any) => AccessRight = ar => {
     const category = toAccessRight(ar.category)
-    if (category) {
-        return ({
-            category: category,
-            group: ar.group,
-        })
-    }
-    else {
+    if (category)
+        switch (category) {
+            case AccessRightValue.GROUP_ACCESS:
+                if (!!ar.group)
+                    return {
+                        category: category,
+                        group: ar.group,
+                    }
+                else
+                    throw `Error in metadata: access right ${AccessRightValue.GROUP_ACCESS} has no 'group' defined`
+            default:
+                if (!!ar.group)
+                    throw `Error in metadata: access right is not ${AccessRightValue.GROUP_ACCESS} but has a 'group' defined`
+                else
+                    return {
+                        category: category,
+                    }
+
+        }
+    else
         throw `Error in metadata: no such access right: '${ar.category}'`
-    }
 }
 
 export const accessRightDeconverter: (ar: AccessRight) => any = ar => clean({

--- a/src/main/typescript/lib/metadata/Audience.ts
+++ b/src/main/typescript/lib/metadata/Audience.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { clean } from "./misc"
 import { DropdownListEntry } from "../../model/DropdownLists"
 
 enum AudienceScheme {

--- a/src/main/typescript/lib/metadata/Contributor.ts
+++ b/src/main/typescript/lib/metadata/Contributor.ts
@@ -70,9 +70,10 @@ const contributorSchemeIdDeconverter: (sv: SchemedValue) => any = schemedValueDe
 const contributorRoleConverter: (cr: any) => string = cr => {
     const scheme = toContributorRoleScheme(cr.scheme)
 
-    if (scheme && scheme === ContributorRoleScheme.DATACITE_CONTRIBUTOR) {
+    if (scheme && scheme === ContributorRoleScheme.DATACITE_CONTRIBUTOR)
         return cr.key
-    }
+    else
+        throw `Error in metadata: no such creator/contributor role scheme: '${cr.scheme}'`
 }
 
 const contributorRoleDeconverter: (r: string) => any = r => clean({
@@ -93,6 +94,11 @@ export const contributorConverter: (c: any) => Contributor = c => {
     })
 }
 
+export const contributorsConverter: (cs: any) => [Contributor[], Contributor[]] = cs => {
+    const contributors: Contributor[] = cs.map(contributorConverter)
+    return lodash.partition(contributors, { role: "RightsHolder" })
+}
+
 export const contributorDeconverter: (c: Contributor) => any = c => clean({
     titles: c.titles,
     initials: c.initials,
@@ -102,8 +108,3 @@ export const contributorDeconverter: (c: Contributor) => any = c => clean({
     role: c.role && contributorRoleDeconverter(c.role),
     organization: c.organization,
 })
-
-export const contributorsConverter: (cs: any) => [Contributor[], Contributor[]] = cs => {
-    const contributors: Contributor[] = cs.map(contributorConverter)
-    return lodash.partition(contributors, { role: "RightsHolder" })
-}

--- a/src/main/typescript/lib/metadata/Date.ts
+++ b/src/main/typescript/lib/metadata/Date.ts
@@ -51,7 +51,14 @@ export interface Dates {
     textDates: QualifiedDate<string>[]
 }
 
-const dateConverter: (d: any) => Date = d => new Date(d)
+const dateConverter: (d: any) => Date = d => {
+    const date: Date = new Date(d)
+
+    if (isNaN(date.getTime()))
+        throw `Error in metadata: invalid date found: '${d}'`
+    else
+        return date
+}
 
 const dateDeconverter: (d: Date) => any = d => dateFormat(d, "isoDateTime")
 
@@ -62,16 +69,16 @@ const qualifiedDateConverter: (dates: DropdownListEntry[]) => (sd: any) => Inter
 
     if (qualifierObj)
         if (scheme && scheme === DateScheme.W3CDTF)
-            return ({
+            return {
                 scheme: scheme,
                 qualifier: qualifierObj.key,
                 value: value,
-            })
+            }
         else
-            return ({
+            return {
                 qualifier: qualifierObj.key,
                 value: value,
-            })
+            }
     else if (sd.qualifier === createdQualifier || sd.qualifier === availableQualifier || sd.qualifier === dateSubmittedQualifier)
         return ({
             scheme: scheme,
@@ -112,7 +119,7 @@ export const qualifiedDatesConverter: (dates: DropdownListEntry[]) => (sds: any)
                     return { ...res, dateAvailable: { qualifier: qualifier, value: dateConverter(value) } }
             case dateSubmittedQualifier:
                 if (res.dateSubmitted)
-                    throw `Error in metadata: multiple dates with qualifier 'submitted' found`
+                    throw `Error in metadata: multiple dates with qualifier 'dateSubmitted' found`
                 else
                     return { ...res, dateSubmitted: { qualifier: qualifier, value: dateConverter(value) } }
             default:

--- a/src/test/typescript/lib/metadata/AccessRight.spec.ts
+++ b/src/test/typescript/lib/metadata/AccessRight.spec.ts
@@ -32,7 +32,7 @@ describe("AccessRight", () => {
             const expected = {
                 category: "OPEN_ACCESS",
             }
-            expect(accessRightConverter(input)).to.deep.equal(expected)
+            expect(accessRightConverter(input)).to.eql(expected)
         })
 
         it("should fail when given an open-access with a group", () => {
@@ -53,7 +53,7 @@ describe("AccessRight", () => {
                 category: "GROUP_ACCESS",
                 group: "my-group",
             }
-            expect(accessRightConverter(input)).to.deep.equal(expected)
+            expect(accessRightConverter(input)).to.eql(expected)
         })
 
         it("should fail when given a group-access without a group", () => {
@@ -96,17 +96,17 @@ describe("AccessRight", () => {
     describe("accessRightDeconverter", () => {
 
         it("should convert an empty AccessRight to an empty output", () => {
-            expect(accessRightDeconverter({})).to.deep.equal({})
+            expect(accessRightDeconverter({})).to.eql({})
         })
 
         it("should convert an AccessRight with only a category into the correct external model", () => {
-            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS })).to.deep
-                .equal({ category: "OPEN_ACCESS" })
+            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS })).to
+                .eql({ category: "OPEN_ACCESS" })
         })
 
         it("should convert an AccessRight with both a category and group into the correct external model", () => {
-            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS, group: "my-group" })).to.deep
-                .equal({ category: "OPEN_ACCESS", group: "my-group" })
+            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS, group: "my-group" })).to
+                .eql({ category: "OPEN_ACCESS", group: "my-group" })
         })
     })
 })

--- a/src/test/typescript/lib/metadata/AccessRight.spec.ts
+++ b/src/test/typescript/lib/metadata/AccessRight.spec.ts
@@ -71,7 +71,7 @@ describe("AccessRight", () => {
                 group: "my-group",
             }
             expect(() => accessRightConverter(input)).to
-                .throw("Error in metadata: no such access right: 'undefined'")
+                .throw("Error in metadata: no such access category: 'undefined'")
         })
 
         it("should fail when an unknown category is given", () => {
@@ -80,7 +80,7 @@ describe("AccessRight", () => {
                 group: "my-group",
             }
             expect(() => accessRightConverter(input)).to
-                .throw("Error in metadata: no such access right: 'unknown-category'")
+                .throw("Error in metadata: no such access category: 'unknown-category'")
         })
 
         it("should fail when an empty object is given", () => {
@@ -89,7 +89,7 @@ describe("AccessRight", () => {
                 // no group here
             }
             expect(() => accessRightConverter(input)).to
-                .throw("Error in metadata: no such access right: 'undefined'")
+                .throw("Error in metadata: no such access category: 'undefined'")
         })
     })
 
@@ -99,12 +99,12 @@ describe("AccessRight", () => {
             expect(accessRightDeconverter({})).to.deep.equal({})
         })
 
-        it("should convert an AccessRight with only a category accordingly", () => {
+        it("should convert an AccessRight with only a category into the correct external model", () => {
             expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS })).to.deep
                 .equal({ category: "OPEN_ACCESS" })
         })
 
-        it("should convert an AccessRight with both a category and group accordingly", () => {
+        it("should convert an AccessRight with both a category and group into the correct external model", () => {
             expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS, group: "my-group" })).to.deep
                 .equal({ category: "OPEN_ACCESS", group: "my-group" })
         })

--- a/src/test/typescript/lib/metadata/AccessRight.spec.ts
+++ b/src/test/typescript/lib/metadata/AccessRight.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from "chai"
+import "mocha"
+import {
+    accessRightConverter,
+    accessRightDeconverter,
+    AccessRightValue,
+} from "../../../../main/typescript/lib/metadata/AccessRight"
+
+describe("AccessRight", () => {
+
+    describe("accessRightConverter", () => {
+
+        it("should convert a valid open-access", () => {
+            const input = {
+                category: "OPEN_ACCESS",
+            }
+            const expected = {
+                category: "OPEN_ACCESS",
+            }
+            expect(accessRightConverter(input)).to.deep.equal(expected)
+        })
+
+        it("should fail when given an open-access with a group", () => {
+            const input = {
+                category: "OPEN_ACCESS",
+                group: "an unexpected group",
+            }
+            expect(() => accessRightConverter(input)).to
+                .throw("Error in metadata: access right is not GROUP_ACCESS but has a 'group' defined")
+        })
+
+        it("should convert a valid group-access", () => {
+            const input = {
+                category: "GROUP_ACCESS",
+                group: "my-group",
+            }
+            const expected = {
+                category: "GROUP_ACCESS",
+                group: "my-group",
+            }
+            expect(accessRightConverter(input)).to.deep.equal(expected)
+        })
+
+        it("should fail when given a group-access without a group", () => {
+            const input = {
+                category: "GROUP_ACCESS",
+                // no group here
+            }
+            expect(() => accessRightConverter(input)).to
+                .throw("Error in metadata: access right GROUP_ACCESS has no 'group' defined")
+        })
+
+        it("should fail when no category is given", () => {
+            const input = {
+                // no category here
+                group: "my-group",
+            }
+            expect(() => accessRightConverter(input)).to
+                .throw("Error in metadata: no such access right: 'undefined'")
+        })
+
+        it("should fail when an unknown category is given", () => {
+            const input = {
+                category: "unknown-category",
+                group: "my-group",
+            }
+            expect(() => accessRightConverter(input)).to
+                .throw("Error in metadata: no such access right: 'unknown-category'")
+        })
+
+        it("should fail when an empty object is given", () => {
+            const input = {
+                // no category here
+                // no group here
+            }
+            expect(() => accessRightConverter(input)).to
+                .throw("Error in metadata: no such access right: 'undefined'")
+        })
+    })
+
+    describe("accessRightDeconverter", () => {
+
+        it("should convert an empty AccessRight to an empty output", () => {
+            expect(accessRightDeconverter({})).to.deep.equal({})
+        })
+
+        it("should convert an AccessRight with only a category accordingly", () => {
+            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS })).to.deep
+                .equal({ category: "OPEN_ACCESS" })
+        })
+
+        it("should convert an AccessRight with both a category and group accordingly", () => {
+            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS, group: "my-group" })).to.deep
+                .equal({ category: "OPEN_ACCESS", group: "my-group" })
+        })
+    })
+})

--- a/src/test/typescript/lib/metadata/Audience.spec.ts
+++ b/src/test/typescript/lib/metadata/Audience.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from "chai"
+import "mocha"
+import {
+    audienceConverter,
+    audienceDeconverter,
+} from "../../../../main/typescript/lib/metadata/Audience"
+import { DropdownListEntry } from "../../../../main/typescript/model/DropdownLists"
+
+describe("Audience", () => {
+
+    const audienceChoices: DropdownListEntry[] = [
+        {
+            key: "D35200",
+            value: "Musicology",
+            displayValue: "------ Musicology",
+        },
+        {
+            key: "D33000",
+            value: "Theology and religious studies",
+            displayValue: "--- Theology and religious studies",
+        },
+    ]
+
+    const converter = audienceConverter(audienceChoices)
+    const deconverter = audienceDeconverter(audienceChoices)
+
+    describe("audienceConverter", () => {
+
+        it("should convert a valid audience", () => {
+            const input = {
+                scheme: "narcis:DisciplineType",
+                key: "D35200",
+                value: "Musicology",
+            }
+            const expected = "D35200"
+            expect(converter(input)).to.deep.equal(expected)
+        })
+
+        it("should fail when no scheme is defined", () => {
+            const input = {
+                // no scheme
+                key: "D35200",
+                value: "Musicology",
+            }
+            expect(() => converter(input)).to
+                .throw("Error in metadata: no such audience scheme: 'undefined'")
+        })
+
+        it("should fail when an invalid scheme is used", () => {
+            const input = {
+                scheme: "invalid-scheme",
+                key: "D35200",
+                value: "Musicology",
+            }
+            expect(() => converter(input)).to
+                .throw("Error in metadata: no such audience scheme: 'invalid-scheme'")
+        })
+
+        it("should fail when no audience key is defined", () => {
+            const input = {
+                scheme: "narcis:DisciplineType",
+                // no key
+                value: "Musicology",
+            }
+            expect(() => converter(input)).to
+                .throw("Error in metadata: no such audience found: 'undefined'")
+        })
+
+        it("should fail when an unknown audience key is used", () => {
+            const input = {
+                scheme: "narcis:DisciplineType",
+                key: "D35200x",
+                value: "Musicology",
+            }
+            expect(() => converter(input)).to
+                .throw("Error in metadata: no such audience found: 'D35200x'")
+        })
+    })
+
+    describe("audienceDeconverter", () => {
+
+        it("should convert a known Audience into the correct external model", () => {
+            expect(deconverter("D33000")).to.deep
+                .equal({ scheme: "narcis:DisciplineType", key: "D33000", value: "Theology and religious studies" })
+        })
+
+        it("should fail when converting an unknown Audience", () => {
+            expect(() => deconverter("D33000x")).to
+                .throw("Error in metadata: no valid audience found for key 'D33000x'")
+        })
+    })
+})

--- a/src/test/typescript/lib/metadata/Audience.spec.ts
+++ b/src/test/typescript/lib/metadata/Audience.spec.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { expect } from "chai"
 import "mocha"
 import {

--- a/src/test/typescript/lib/metadata/Audience.spec.ts
+++ b/src/test/typescript/lib/metadata/Audience.spec.ts
@@ -48,7 +48,7 @@ describe("Audience", () => {
                 value: "Musicology",
             }
             const expected = "D35200"
-            expect(converter(input)).to.deep.equal(expected)
+            expect(converter(input)).to.eql(expected)
         })
 
         it("should fail when no scheme is defined", () => {
@@ -95,8 +95,8 @@ describe("Audience", () => {
     describe("audienceDeconverter", () => {
 
         it("should convert a known Audience into the correct external model", () => {
-            expect(deconverter("D33000")).to.deep
-                .equal({ scheme: "narcis:DisciplineType", key: "D33000", value: "Theology and religious studies" })
+            expect(deconverter("D33000")).to
+                .eql({ scheme: "narcis:DisciplineType", key: "D33000", value: "Theology and religious studies" })
         })
 
         it("should fail when converting an unknown Audience", () => {

--- a/src/test/typescript/lib/metadata/Contributor.spec.ts
+++ b/src/test/typescript/lib/metadata/Contributor.spec.ts
@@ -66,7 +66,7 @@ describe("Contributor", () => {
                 role: "ContactPerson",
                 organization: "KNAW",
             }
-            expect(contributorConverter(input)).to.deep.equal(expected)
+            expect(contributorConverter(input)).to.eql(expected)
         })
 
         it("should convert an empty input to an internal representation with empty strings", () => {
@@ -80,7 +80,7 @@ describe("Contributor", () => {
                 role: "",
                 organization: "",
             }
-            expect(contributorConverter(input)).to.deep.equal(expected)
+            expect(contributorConverter(input)).to.eql(expected)
         })
 
         it("should fail when using an invalid contributor schemeId", () => {
@@ -169,7 +169,7 @@ describe("Contributor", () => {
                 role: "RightsHolder",
                 organization: "rightsHolder1",
             }
-            expect(contributorsConverter([input1, input2])).to.deep.equal([[expected2], [expected1]])
+            expect(contributorsConverter([input1, input2])).to.eql([[expected2], [expected1]])
         })
     })
 
@@ -186,7 +186,7 @@ describe("Contributor", () => {
                 organization: "",
             }
             const expected = {}
-            expect(contributorDeconverter(input)).to.deep.equal(expected)
+            expect(contributorDeconverter(input)).to.eql(expected)
         })
 
         it("should convert a Contributor into the correct external model", () => {
@@ -230,7 +230,7 @@ describe("Contributor", () => {
                 },
                 organization: "KNAW",
             }
-            expect(contributorDeconverter(input)).to.deep.equal(expected)
+            expect(contributorDeconverter(input)).to.eql(expected)
         })
     })
 })

--- a/src/test/typescript/lib/metadata/Contributor.spec.ts
+++ b/src/test/typescript/lib/metadata/Contributor.spec.ts
@@ -1,0 +1,221 @@
+import { expect } from "chai"
+import "mocha"
+import {
+    Contributor,
+    contributorConverter, contributorDeconverter,
+    contributorsConverter,
+} from "../../../../main/typescript/lib/metadata/Contributor"
+
+describe("Contributor", () => {
+
+    describe("contributorConverter", () => {
+
+        it("should convert a valid contributor", () => {
+            const input = {
+                titles: "Drs.",
+                initials: "D.A.",
+                insertions: "",
+                surname: "NS",
+                ids: [
+                    {
+                        scheme: "id-type:DAI",
+                        value: "123456",
+                    },
+                    {
+                        scheme: "id-type:ORCID",
+                        value: "abcdef",
+                    },
+                ],
+                role: {
+                    scheme: "datacite:contributorType",
+                    key: "ContactPerson",
+                    value: "Contact Person",
+                },
+                organization: "KNAW",
+            }
+            const expected: Contributor = {
+                titles: "Drs.",
+                initials: "D.A.",
+                insertions: "",
+                surname: "NS",
+                ids: [
+                    {
+                        scheme: "id-type:DAI",
+                        value: "123456",
+                    },
+                    {
+                        scheme: "id-type:ORCID",
+                        value: "abcdef",
+                    },
+                ],
+                role: "ContactPerson",
+                organization: "KNAW",
+            }
+            expect(contributorConverter(input)).to.deep.equal(expected)
+        })
+
+        it("should convert an empty input to an internal representation with empty strings", () => {
+            const input = {}
+            const expected: Contributor = {
+                titles: "",
+                initials: "",
+                insertions: "",
+                surname: "",
+                ids: [{ scheme: "", value: "" }],
+                role: "",
+                organization: "",
+            }
+            expect(contributorConverter(input)).to.deep.equal(expected)
+        })
+
+        it("should fail when using an invalid contributor schemeId", () => {
+            const input = {
+                ids: [
+                    {
+                        scheme: "id-type:invalid",
+                        value: "123456",
+                    },
+                ],
+            }
+            expect(() => contributorConverter(input)).to
+                .throw("Error in metadata: no such creator/contributor scheme: 'id-type:invalid'")
+        })
+
+        it("should fail when using an invalid contributor role scheme", () => {
+            const input = {
+                role: {
+                    scheme: "datacite:invalid",
+                    key: "ContactPerson",
+                    value: "Contact Person",
+                },
+            }
+            expect(() => contributorConverter(input)).to
+                .throw("Error in metadata: no such creator/contributor role scheme: 'datacite:invalid'")
+        })
+    })
+
+    describe("contributorsConverter", () => {
+
+        it("should convert and partition valid contributors", () => {
+            const input1 = {
+                titles: "Drs.",
+                initials: "D.A.",
+                insertions: "",
+                surname: "NS",
+                ids: [
+                    {
+                        scheme: "id-type:DAI",
+                        value: "123456",
+                    },
+                    {
+                        scheme: "id-type:ORCID",
+                        value: "abcdef",
+                    },
+                ],
+                role: {
+                    scheme: "datacite:contributorType",
+                    key: "ContactPerson",
+                    value: "Contact Person",
+                },
+                organization: "KNAW",
+            }
+            const input2 = {
+                organization: "rightsHolder1",
+                role: {
+                    scheme: "datacite:contributorType",
+                    key: "RightsHolder",
+                    value: "rightsholder",
+                },
+            }
+            const expected1: Contributor = {
+                titles: "Drs.",
+                initials: "D.A.",
+                insertions: "",
+                surname: "NS",
+                ids: [
+                    {
+                        scheme: "id-type:DAI",
+                        value: "123456",
+                    },
+                    {
+                        scheme: "id-type:ORCID",
+                        value: "abcdef",
+                    },
+                ],
+                role: "ContactPerson",
+                organization: "KNAW",
+            }
+            const expected2: Contributor = {
+                titles: "",
+                initials: "",
+                insertions: "",
+                surname: "",
+                ids: [{ scheme: "", value: "" }],
+                role: "RightsHolder",
+                organization: "rightsHolder1",
+            }
+            expect(contributorsConverter([input1, input2])).to.deep.equal([[expected2], [expected1]])
+        })
+    })
+
+    describe("contributorDeconverter", () => {
+
+        it("should convert an empty Contributor to an empty object", () => {
+            const input: Contributor = {
+                titles: "",
+                initials: "",
+                insertions: "",
+                surname: "",
+                ids: [{ scheme: "", value: "" }],
+                role: "",
+                organization: "",
+            }
+            const expected = {}
+            expect(contributorDeconverter(input)).to.deep.equal(expected)
+        })
+
+        it("should convert a Contributor into the correct external model", () => {
+            const input: Contributor = {
+                titles: "Drs.",
+                initials: "D.A.",
+                insertions: "van",
+                surname: "NS",
+                ids: [
+                    {
+                        scheme: "id-type:DAI",
+                        value: "123456",
+                    },
+                    {
+                        scheme: "id-type:ORCID",
+                        value: "abcdef",
+                    },
+                ],
+                role: "ContactPerson",
+                organization: "KNAW",
+            }
+            const expected = {
+                titles: "Drs.",
+                initials: "D.A.",
+                insertions: "van",
+                surname: "NS",
+                ids: [
+                    {
+                        scheme: "id-type:DAI",
+                        value: "123456",
+                    },
+                    {
+                        scheme: "id-type:ORCID",
+                        value: "abcdef",
+                    },
+                ],
+                role: {
+                    scheme: "datacite:contributorType",
+                    key: "ContactPerson",
+                    value: "???",
+                },
+                organization: "KNAW",
+            }
+            expect(contributorDeconverter(input)).to.deep.equal(expected)
+        })
+    })
+})

--- a/src/test/typescript/lib/metadata/Contributor.spec.ts
+++ b/src/test/typescript/lib/metadata/Contributor.spec.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { expect } from "chai"
 import "mocha"
 import {

--- a/src/test/typescript/lib/metadata/Date.spec.ts
+++ b/src/test/typescript/lib/metadata/Date.spec.ts
@@ -22,6 +22,7 @@ import {
     qualifiedDatesConverter, qualifiedDateStringDeconverter,
 } from "../../../../main/typescript/lib/metadata/Date"
 import { DropdownListEntry } from "../../../../main/typescript/model/DropdownLists"
+import * as dateFormat from "dateformat"
 
 describe("Date", () => {
 
@@ -223,7 +224,7 @@ describe("Date", () => {
             }
             const expected = {
                 scheme: "dcterms:W3CDTF",
-                value: "2018-03-14T01:00:00+0100",
+                value: dateFormat(new Date("2018-03-14"), "isoDateTime"), // don't just match against the String, because of time zone issues
                 qualifier: "dcterms:issued",
             }
             expect(qualifiedDateDeconverter(input)).to.deep.equal(expected)

--- a/src/test/typescript/lib/metadata/Date.spec.ts
+++ b/src/test/typescript/lib/metadata/Date.spec.ts
@@ -1,0 +1,240 @@
+import { expect } from "chai"
+import "mocha"
+import {
+    Dates,
+    QualifiedDate,
+    qualifiedDateDeconverter,
+    qualifiedDatesConverter, qualifiedDateStringDeconverter,
+} from "../../../../main/typescript/lib/metadata/Date"
+import { DropdownListEntry } from "../../../../main/typescript/model/DropdownLists"
+
+describe("Date", () => {
+
+    const dateChoices: DropdownListEntry[] = [
+        {
+            key: "dcterms:date",
+            value: "Date",
+            displayValue: "Date",
+        },
+        {
+            key: "dcterms:valid",
+            value: "Valid",
+            displayValue: "Valid",
+        },
+        {
+            key: "dcterms:issued",
+            value: "Issued",
+            displayValue: "Issued",
+        },
+        {
+            key: "dcterms:modified",
+            value: "Modified",
+            displayValue: "Modified",
+        },
+        {
+            key: "dcterms:dateAccepted",
+            value: "Date accepted",
+            displayValue: "Date accepted",
+        },
+        {
+            key: "dcterms:dateCopyrighted",
+            value: "Date copyrighted",
+            displayValue: "Date copyrighted",
+        },
+    ]
+
+    const converter = qualifiedDatesConverter(dateChoices)
+
+    describe("qualifiedDatesConverter", () => {
+
+        it("should convert a valid sequence of dates and split them correctly", () => {
+            const input = [
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-18",
+                    qualifier: "dcterms:dateCopyrighted",
+                },
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-17",
+                    qualifier: "dcterms:valid",
+                },
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-19",
+                    qualifier: "dcterms:created",
+                },
+                {
+                    value: "2018-02-02",
+                    qualifier: "dcterms:modified",
+                },
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-14",
+                    qualifier: "dcterms:available",
+                },
+                {
+                    value: "Groundhog day",
+                    qualifier: "dcterms:issued",
+                },
+            ]
+            const expected: Dates = {
+                dateCreated: {
+                    qualifier: "dcterms:created",
+                    value: new Date("2018-03-19"),
+                },
+                dateAvailable: {
+                    qualifier: "dcterms:available",
+                    value: new Date("2018-03-14"),
+                },
+                dates: [
+                    {
+                        qualifier: "dcterms:dateCopyrighted",
+                        value: new Date("2018-03-18"),
+                    },
+                    {
+                        qualifier: "dcterms:valid",
+                        value: new Date("2018-03-17"),
+                    },
+                ],
+                textDates: [
+                    {
+                        qualifier: "dcterms:modified",
+                        value: "2018-02-02",
+                    },
+                    {
+                        qualifier: "dcterms:issued",
+                        value: "Groundhog day",
+                    },
+                ],
+            }
+            expect(converter(input)).to.deep.equal(expected)
+        })
+
+        it("should fail when no qualifier is given", () => {
+            const input = [
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-18",
+                    // no qualifier
+                },
+            ]
+            expect(() => converter(input)).to
+                .throw("Error in metadata: no such date qualifier: 'undefined'")
+        })
+
+        it("should fail when an invalid qualifier is given", () => {
+            const input = [
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-18",
+                    qualifier: "dcterms:dateInvalid"
+                },
+            ]
+            expect(() => converter(input)).to
+                .throw("Error in metadata: no such date qualifier: 'dcterms:dateInvalid'")
+        })
+
+        it("should fail when multiple dateCreated fields are given", () => {
+            const input = [
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-18",
+                    qualifier: "dcterms:created"
+                },
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-19",
+                    qualifier: "dcterms:created"
+                },
+            ]
+            expect(() => converter(input)).to
+                .throw("Error in metadata: multiple dates with qualifier 'created' found")
+        })
+
+        it("should fail when multiple dateAvailable fields are given", () => {
+            const input = [
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-18",
+                    qualifier: "dcterms:available"
+                },
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-19",
+                    qualifier: "dcterms:available"
+                },
+            ]
+            expect(() => converter(input)).to
+                .throw("Error in metadata: multiple dates with qualifier 'available' found")
+        })
+
+        it("should fail when multiple dateSubmitted fields are given", () => {
+            const input = [
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-18",
+                    qualifier: "dcterms:dateSubmitted"
+                },
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "2018-03-19",
+                    qualifier: "dcterms:dateSubmitted"
+                },
+            ]
+            expect(() => converter(input)).to
+                .throw("Error in metadata: multiple dates with qualifier 'dateSubmitted' found")
+        })
+
+        it("should fail when the date is not properly formatted", () => {
+            const input = [
+                {
+                    scheme: "dcterms:W3CDTF",
+                    value: "20180318",
+                    qualifier: "dcterms:dateSubmitted"
+                },
+            ]
+            expect(() => converter(input)).to
+                .throw("Error in metadata: invalid date found: '20180318'")
+        })
+    })
+
+    describe("qualifiedDateDeconverter", () => {
+
+        it("should convert a QualifiedDate into the correct external model", () => {
+            const input: QualifiedDate<Date> = {
+                qualifier: "dcterms:issued",
+                value: new Date("2018-03-14")
+            }
+            const expected = {
+                scheme: "dcterms:W3CDTF",
+                value: "2018-03-14T01:00:00+0100",
+                qualifier: "dcterms:issued",
+            }
+            expect(qualifiedDateDeconverter(input)).to.deep.equal(expected)
+        })
+
+        it("should convert a QualifiedDate without a value into an empty object", () => {
+            const input: QualifiedDate<Date> = {
+                qualifier: "dcterms:issued",
+            }
+            const expected = {}
+            expect(qualifiedDateDeconverter(input)).to.deep.equal(expected)
+        })
+    })
+
+    describe("qualifiedDateStringDeconverter", () => {
+
+        it("should convert a QualifiedDate with string value into the correct external model", () => {
+            const input: QualifiedDate<string> = {
+                qualifier: "dcterms:issued",
+                value: "today",
+            }
+            const expected = {
+                value: "today",
+                qualifier: "dcterms:issued",
+            }
+            expect(qualifiedDateStringDeconverter(input)).to.deep.equal(expected)
+        })
+    })
+})

--- a/src/test/typescript/lib/metadata/Date.spec.ts
+++ b/src/test/typescript/lib/metadata/Date.spec.ts
@@ -124,7 +124,7 @@ describe("Date", () => {
                     },
                 ],
             }
-            expect(converter(input)).to.deep.equal(expected)
+            expect(converter(input)).to.eql(expected)
         })
 
         it("should fail when no qualifier is given", () => {
@@ -227,7 +227,7 @@ describe("Date", () => {
                 value: dateFormat(new Date("2018-03-14"), "isoDateTime"), // don't just match against the String, because of time zone issues
                 qualifier: "dcterms:issued",
             }
-            expect(qualifiedDateDeconverter(input)).to.deep.equal(expected)
+            expect(qualifiedDateDeconverter(input)).to.eql(expected)
         })
 
         it("should convert a QualifiedDate without a value into an empty object", () => {
@@ -235,7 +235,7 @@ describe("Date", () => {
                 qualifier: "dcterms:issued",
             }
             const expected = {}
-            expect(qualifiedDateDeconverter(input)).to.deep.equal(expected)
+            expect(qualifiedDateDeconverter(input)).to.eql(expected)
         })
     })
 
@@ -250,7 +250,7 @@ describe("Date", () => {
                 value: "today",
                 qualifier: "dcterms:issued",
             }
-            expect(qualifiedDateStringDeconverter(input)).to.deep.equal(expected)
+            expect(qualifiedDateStringDeconverter(input)).to.eql(expected)
         })
     })
 })

--- a/src/test/typescript/lib/metadata/Date.spec.ts
+++ b/src/test/typescript/lib/metadata/Date.spec.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { expect } from "chai"
 import "mocha"
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "sourceMap": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "module": "es2015",
     "target": "es2017",
     "jsx": "react",
     "moduleResolution": "node",


### PR DESCRIPTION
Introduces unit testing with Maven and Travis integration, as well as a first couple of tests.
For now, the aim of unit testing is to test the (de)conversion between external and internal JSON data.

More tests will come in consecutive pull requests

@DANS-KNAW/easy for review