### PR TITLE
Fix mockserver build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Self-deposit user web-interface",
   "main": "src/main/typescript/client.tsx",
   "scripts": {
-    "start": "NODE_ENV=development webpack-dev-server --mode development --hot --open --config webpack/dev.config.js",
-    "build": "NODE_ENV=production webpack --mode production --config webpack/prod.config.js",
+    "start": "NODE_ENV=development webpack-dev-server --hot --open --config webpack/dev.config.js",
+    "build": "NODE_ENV=production webpack --config webpack/prod.config.js",
     "test": "mocha -r ts-node/register src/test/typescript/**/*.spec.ts",
-    "mockserver": "webpack --mode development --config webpack/mockserver.config.js && node target/build-mockserver/server.js"
+    "mockserver": "webpack --config webpack/mockserver.config.js && node target/build-mockserver/server.js"
   },
   "repository": {
     "type": "git",

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -19,6 +19,8 @@ const baseConfig = require('./base.config.js');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = merge(baseConfig, {
+    mode: 'development',
+
     // Enable sourcemaps for debugging webpack's output.
     devtool: 'eval-source-map',
     output: {

--- a/webpack/mockserver.config.js
+++ b/webpack/mockserver.config.js
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const path = require('path');
 const nodeExternals = require('webpack-node-externals');
 
+const rootPath = process.cwd();
+const buildPath = 'target/build-mockserver';
+
 module.exports = {
+    mode: 'development',
+
     entry: './src/test/typescript/mockserver/server.ts',
     output: {
-        filename: './target/build-mockserver/server.js'
+        path: path.join(rootPath, buildPath),
+        filename: 'server.js'
     },
 
     resolve: {
@@ -44,6 +51,15 @@ module.exports = {
             }
         ],
     },
+
     target: 'node',
+
     externals: [nodeExternals()],
+
+    plugins: [
+        // Clear out `target/build` directory between builds
+        new CleanWebpackPlugin([buildPath], {
+            root: rootPath,
+        }),
+    ],
 };

--- a/webpack/mockserver.config.js
+++ b/webpack/mockserver.config.js
@@ -15,6 +15,7 @@
  */
 const path = require('path');
 const nodeExternals = require('webpack-node-externals');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
 
 const rootPath = process.cwd();
 const buildPath = 'target/build-mockserver';

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -22,6 +22,8 @@ const baseConfig = require('./base.config.js');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = merge(baseConfig, {
+    mode: 'production',
+
     output: {
         path: path.join(process.cwd(), 'target/build'),
         filename: '[name].bundle.[chunkhash].js',


### PR DESCRIPTION
#### When applied it will
* fix the build scripts for the mockserver. It turned out that the new Webpack v4 (#39) didn't put the compiled `*.js` file in the right place, which caused the mockserver not to be started.
* replace the `--mode` flags with properties in the `(dev|prod).config.js` files.

@DANS-KNAW/easy for review