### PR TITLE
split EasyLogin into multiple components

### DIFF
--- a/src/main/resources/css/login.css
+++ b/src/main/resources/css/login.css
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.form-group input {
+    /*       tb  lr*/
+    padding: 5px 8px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    font-size: 14px;
+}

--- a/src/main/typescript/components/login/EasyLogin.tsx
+++ b/src/main/typescript/components/login/EasyLogin.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react"
+import { Component } from "react"
+import { ReduxAction } from "../../lib/redux"
+import { authenticate } from "../../actions/authenticationActions"
+import { Field, InjectedFormProps, reduxForm } from "redux-form"
+import { AppState } from "../../model/AppState"
+import { compose } from "redux"
+import { connect } from "react-redux"
+import TextField from "../../lib/formComponents/TextField"
+import LoginCard from "./LoginCard"
+
+interface EasyLoginProps {
+    authenticate: (username: string, password: string) => ReduxAction<Promise<any>>
+    authenticating: boolean
+    errorMessage?: string
+}
+
+interface EasyLoginData {
+    username: string
+    password: string
+}
+
+type AllEasyLoginProps = EasyLoginProps & InjectedFormProps<EasyLoginData>
+
+class EasyLogin extends Component<AllEasyLoginProps> {
+    callAuthenticate = (formValues: EasyLoginData) => {
+        this.props.authenticate(formValues.username, formValues.password)
+    }
+
+    render() {
+        const {authenticating, errorMessage, handleSubmit} = this.props
+
+        // TODO add form validation
+        return (
+            <LoginCard authenticating={authenticating}
+                       errorMessage={errorMessage}
+                       onSubmit={handleSubmit(this.callAuthenticate)}
+                       header={() => <>EASY account</>}>
+                <div className="container pl-0 pr-0 pb-0 ml-0 mr-0">
+                    <div className="row ml-0 mr-0 mb-1 form-group">
+                        <label htmlFor="username"
+                               className="col-12 col-md-5 col-lg-4 col-form-label">Username</label>
+                        <div className="col-12 col-md-7 col-lg-8">
+                            <Field name="username"
+                                   label="Username"
+                                   id="username"
+                                   autoFocus
+                                   required
+                                   component={TextField}/>
+                        </div>
+                    </div>
+                    <div className="form-group row ml-0 mr-0 mb-0">
+                        <label htmlFor="password"
+                               className="col-12 col-md-5 col-lg-4 col-form-label">Password</label>
+                        <div className="col-12 col-md-7 col-lg-8">
+                            <Field name="password"
+                                   label="Password"
+                                   id="password"
+                                   required
+                                   component={TextField}/>
+                        </div>
+                    </div>
+                </div>
+            </LoginCard>
+        )
+    }
+}
+
+const mapEasyLoginStateToProps = (state: AppState) => ({
+    authenticating: state.authenticatedUser.isAuthenticating,
+    errorMessage: state.authenticatedUser.authenticationError,
+})
+
+const composedEasyLoginHOC = compose(
+    connect(mapEasyLoginStateToProps, { authenticate }),
+    reduxForm<EasyLoginData>({ form: "easyLogin" }),
+)
+
+export default composedEasyLoginHOC(EasyLogin)

--- a/src/main/typescript/components/login/LoginCard.tsx
+++ b/src/main/typescript/components/login/LoginCard.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react"
+import { ComponentType, SFC, SyntheticEvent } from "react"
+
+interface LoginCardProps {
+    authenticating: boolean
+    errorMessage?: string
+    header: ComponentType
+
+    onSubmit(e: SyntheticEvent): void
+}
+
+const LoginCard: SFC<LoginCardProps> = ({ children, authenticating, errorMessage, header: Header, onSubmit }) => (
+    <div className="card pl-0 pr-0 mb-4 mb-md-0 col col-12 col-md-5">
+        <form onSubmit={onSubmit}>
+            <div className="card-header bg-primary text-white">
+                <Header/>
+            </div>
+            <div className="card-body pl-0 pr-0 pb-0 ml-0 mr-0">
+                {children}
+                <button className="btn btn-primary ml-3"
+                        type="submit"
+                        disabled={authenticating}>Login</button>
+            </div>
+            {errorMessage && <span>{errorMessage}<br/></span>}
+        </form>
+    </div>
+)
+
+export default LoginCard

--- a/src/main/typescript/components/login/LoginPage.tsx
+++ b/src/main/typescript/components/login/LoginPage.tsx
@@ -14,83 +14,35 @@
  * limitations under the License.
  */
 import * as React from "react"
-import { Component } from "react"
 import { Redirect, RouteComponentProps } from "react-router"
-import { compose } from "redux"
-import { connect } from "react-redux"
-import { InjectedFormProps, reduxForm, Field } from "redux-form"
-import { ReduxAction } from "../../lib/redux"
-import { authenticate } from "../../actions/authenticationActions"
 import { AppState } from "../../model/AppState"
 import { homeRoute } from "../../constants/clientRoutes"
+import EasyLogin from "./EasyLogin"
+import { connect } from "react-redux"
+import "../../../resources/css/login"
 
 interface LoginPageProps {
-    authenticate: (username: string, password: string) => ReduxAction<Promise<any>>
     authenticated: boolean
-    authenticating: boolean
-    errorMessage: Error
 }
 
-interface LoginPageData {
-    loginName: string
-    loginPassword: string
-}
+type AllDemoFormProps = LoginPageProps & RouteComponentProps<any>
 
-type AllDemoFormProps = LoginPageProps & RouteComponentProps<any> & InjectedFormProps<LoginPageData>
+const LoginPage = ({ authenticated, location }: AllDemoFormProps) => {
+    const { from } = location.state || { from: { pathname: homeRoute } }
 
-class LoginPage extends Component<AllDemoFormProps> {
-    constructor(props: AllDemoFormProps) {
-        super(props)
-    }
+    return authenticated
+        ? <Redirect to={from}/>
+        : <div className="container">
+            <div className="row justify-content-around">
+                <EasyLogin/>
 
-    callAuthenticate = (formValues: LoginPageData) => {
-        this.props.authenticate(formValues.loginName, formValues.loginPassword)
-    }
-
-    render() {
-        const { authenticated, errorMessage, location, handleSubmit } = this.props
-        const { from } = location.state || { from: { pathname: homeRoute } }
-
-        return authenticated
-            ? <Redirect to={from}/>
-            :
-            <div className="row">
-                <div className={"card pl-0 pr-0 col-4 offset-md-4"}>
-                    <form onSubmit={handleSubmit(this.callAuthenticate)}>
-                        <p className={"card-header ml-0 mr-0 bg-primary text-white"}>EASY account</p>
-
-                        <div  className={"card-body pl-0 pr-2 ml-0 mr-0"}>
-                        <p className={"col-12"}>You must log in to view this page at {from.pathname}</p>
-                        <div className={"mb-1"}>
-                        <label className={"col-4"}>Username</label>
-                        <Field className={"col-8"} name="loginName" type="text" component="input" autoFocus required/>
-                        </div>
-                        <div>
-                        <label className={"col-4"}>Password</label>
-                        <Field className={"col-8"} type="password" name="loginPassword" component="input" required/>
-                        </div>
-                        <div className={"col-12"}>
-                            <button className={"btn btn-primary"} type="submit"
-                                    disabled={this.props.authenticating}>Login
-                            </button>
-                        </div>
-                        {errorMessage && <span>{errorMessage.message}<br/></span>}
-                        </div>
-                    </form>
-                </div>
+                {/* TODO other kinds of login forms here*/}
             </div>
-    }
+        </div>
 }
 
 const mapStateToProps = (state: AppState) => ({
     authenticated: state.authenticatedUser.isAuthenticated,
-    authenticating: state.authenticatedUser.isAuthenticating,
-    errorMessage: state.authenticatedUser.authenticationError,
 })
 
-const composedHOC = compose(
-    connect(mapStateToProps, { authenticate }),
-    reduxForm<LoginPageData>({ form: "login" }),
-)
-
-export default composedHOC(LoginPage)
+export default connect(mapStateToProps)(LoginPage)

--- a/src/main/typescript/reducers/index.ts
+++ b/src/main/typescript/reducers/index.ts
@@ -41,6 +41,7 @@ export default combineReducers({
     user: userReducer,
     form: formReducer.plugin({
         depositForm: changeReducer,
+        easyLogin: changeReducer,
     }),
     router: routerReducer,
     deposits: depositOverviewReducer,


### PR DESCRIPTION
Amendment on https://github.com/DANS-KNAW/easy-deposit-ui/pull/48.

**When applied it will**
* Split the login component into multiple smaller components
* Clean up unused or unnecessary `className`s

@DANS-KNAW/easy for review
@lindareijnhoudt @jo-pol hope you like it...

**_browser_**
![image](https://user-images.githubusercontent.com/5938204/41624145-0b65107a-7415-11e8-89a8-46cafa7ae371.png)

**_iPhone 5/SE_**
![image](https://user-images.githubusercontent.com/5938204/41624180-2331a330-7415-11e8-8e36-f37528a955a2.png)
