### PR TITLE
EASY-1601: Multi tiered license agreement selection

### DIFF
--- a/src/main/resources/constants/licenses.json
+++ b/src/main/resources/constants/licenses.json
@@ -3,14 +3,6 @@
     "title": "CC0-1.0",
     "viewName": "CC0-1.0"
   },
-  "http://creativecommons.org/licenses/by-nc/3.0": {
-    "title": "BY-NC-3.0",
-    "viewName": "BY-NC-3.0"
-  },
-  "http://creativecommons.org/licenses/by-nc-sa/3.0": {
-    "title": "BY-NC-SA-3.0",
-    "viewName": "BY-NC-SA-3.0"
-  },
   "http://creativecommons.org/licenses/by/4.0": {
     "title": "CC-BY-4.0",
     "viewName": "CC-BY-4.0"
@@ -34,6 +26,14 @@
   "http://creativecommons.org/licenses/by-nc-sa/4.0/": {
     "title": "CC-BY-NC-SA-4.0",
     "viewName": "CC-BY-NC-SA-4.0"
+  },
+  "http://creativecommons.org/licenses/by-nc/3.0": {
+    "title": "BY-NC-3.0",
+    "viewName": "BY-NC-3.0"
+  },
+  "http://creativecommons.org/licenses/by-nc-sa/3.0": {
+    "title": "BY-NC-SA-3.0",
+    "viewName": "BY-NC-SA-3.0"
   },
   "http://opensource.org/licenses/BSD-2-Clause": {
     "title": "BSD-2-Clause",

--- a/src/main/resources/css/form.css
+++ b/src/main/resources/css/form.css
@@ -163,3 +163,7 @@
 .input-element .accessrights-field .group-field {
     align-self: flex-end;
 }
+
+.input-element .license-field .show-more:hover {
+    cursor: pointer;
+}

--- a/src/main/resources/css/form.css
+++ b/src/main/resources/css/form.css
@@ -164,6 +164,10 @@
     align-self: flex-end;
 }
 
+.input-element .license-field .radio-choices .external-link {
+    color: #2125299c
+}
+
 .input-element .license-field .show-more:hover {
     cursor: pointer;
 }

--- a/src/main/resources/css/styling.css
+++ b/src/main/resources/css/styling.css
@@ -60,6 +60,6 @@ main h1 {
     font-size: 25px;
 }
 
-main a {
+main a.black-link {
     color: black;
 }

--- a/src/main/resources/css/styling.css
+++ b/src/main/resources/css/styling.css
@@ -59,7 +59,3 @@ main.container {
 main h1 {
     font-size: 25px;
 }
-
-main a.black-link {
-    color: black;
-}

--- a/src/main/typescript/components/form/DepositFormPage.tsx
+++ b/src/main/typescript/components/form/DepositFormPage.tsx
@@ -50,11 +50,9 @@ class DepositFormPage extends Component<DepositFormPageProps> {
                 <h1>Deposit your data</h1>
                 <p>
                     Read the instructions
-                    (<a className="text-primary"
-                        href="https://dans.knaw.nl/en/deposit/information-about-depositing-data"
+                    (<a href="https://dans.knaw.nl/en/deposit/information-about-depositing-data"
                         target="_blank"><u>English</u></a>)
-                    (<a className="text-primary"
-                        href="https://dans.knaw.nl/nl/deponeren/toelichting-data-deponeren"
+                    (<a href="https://dans.knaw.nl/nl/deponeren/toelichting-data-deponeren"
                         target="_blank"><u>Nederlands</u></a>)
                 </p>
                 <DepositForm/>

--- a/src/main/typescript/components/form/parts/DepositLicenseForm.tsx
+++ b/src/main/typescript/components/form/parts/DepositLicenseForm.tsx
@@ -32,7 +32,7 @@ const DepositLicenseForm = () => (
             <p>
                 {/* TODO fill in the correct href in the <a> */}
                 In order to deposit a dataset, you must accept and understand
-                the <a className="text-primary" href="#" target="_blank">Licence agreement</a> (PDF).
+                the <a href="#" target="_blank">Licence agreement</a> (PDF).
             </p>
         </div>
 

--- a/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
@@ -22,7 +22,7 @@ import { DropdownListEntry } from "../../../../model/DropdownLists"
 import { AppState } from "../../../../model/AppState"
 import asField from "../../../../lib/formComponents/FieldHOC"
 import { DropdownFieldInput } from "../../../../lib/formComponents/DropDownField"
-import {RadioChoicesInput as LibRadioChoices} from "../../../../lib/formComponents/RadioChoices"
+import { RadioChoicesInput } from "../../../../lib/formComponents/RadioChoices"
 
 interface AccessRightsFieldProps {
     userGroups: DropdownListEntry[]
@@ -53,7 +53,7 @@ const AccessRightsField = ({ userGroups, input, meta, label }: WrappedFieldProps
                 <Field name={`${input.name}.category`}
                        divClassName="radio-button"
                        choices={choices}
-                       component={LibRadioChoices}/>
+                       component={RadioChoicesInput}/>
             </div>
             {withUserGroups && <div className="col col-md-4 group-field">
                 <Field name={`${input.name}.group`}

--- a/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
@@ -53,15 +53,12 @@ class LicenseChoices extends Component<WrappedFieldProps & LicenseChoicesProps, 
         <span><a className="external-link" href={link} target="_blank"><i className="fas fa-external-link-square-alt"/></a> {text}</span>
     )
 
-    render() {
-        if (this.state.showCount < 1)
-            this.setState(prevState => ({ ...prevState, showCount: 1 }))
-
+    choices() {
+        const value = this.props.input.value
         const actualChoices = this.props.choices.slice(0, this.state.showCount).map(entry => ({
             title: entry.key,
             value: this.radioChoice(entry.value, entry.key),
         }))
-        const value = this.props.input.value
         if (!actualChoices.find(({ title }) => title === value)) {
             const original = this.props.choices.find(({ key }) => key === value)
             if (original) {
@@ -71,17 +68,24 @@ class LicenseChoices extends Component<WrappedFieldProps & LicenseChoicesProps, 
                 })
             }
         }
-        const containsAllChoices = this.props.choices.length < this.state.showCount
 
-        const radioChoices = <RadioChoicesInput {...this.props} divClassName="radio-choices" choices={actualChoices}/>
-        const showMore = !containsAllChoices && <a className="show-more" onClick={this.showMoreLicenses}>show more...</a>
+        return actualChoices
+    }
+
+    render() {
+        if (this.state.showCount < 1)
+            this.setState(prevState => ({ ...prevState, showCount: 1 }))
 
         return (
             <div className="license-field">
-                {radioChoices}
-                {showMore}
+                <RadioChoicesInput {...this.props} divClassName="radio-choices" choices={this.choices()}/>
+                {this.props.choices.length >= this.state.showCount && this.renderShowMore()}
             </div>
         )
+    }
+
+    private renderShowMore() {
+        return <a className="show-more" onClick={this.showMoreLicenses}>show more...</a>
     }
 }
 

--- a/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
@@ -50,7 +50,12 @@ class LicenseChoices extends Component<WrappedFieldProps & LicenseChoicesProps, 
     }
 
     radioChoice = (text: string, link: string) => (
-        <span>{text} <a href={link} target="_blank"><i className="fas fa-info-circle"/></a></span>
+        <span>{text} <a //className="black-link"
+                        href={link}
+                        target="_blank">
+            <i className="fas fa-info-circle"/>
+        </a>
+        </span>
     )
 
     render() {
@@ -75,13 +80,13 @@ class LicenseChoices extends Component<WrappedFieldProps & LicenseChoicesProps, 
 
         const radioChoices = <RadioChoicesInput {...this.props} choices={actualChoices}/>
         // TODO style the <a/> properly
-        const showMore = !containsAllChoices && <a onClick={this.showMoreLicenses}>show more...</a>
+        const showMore = !containsAllChoices && <a className="show-more" onClick={this.showMoreLicenses}>show more...</a>
 
         return (
-            <>
+            <div className="license-field">
                 {radioChoices}
                 {showMore}
-            </>
+            </div>
         )
     }
 }

--- a/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
@@ -50,12 +50,7 @@ class LicenseChoices extends Component<WrappedFieldProps & LicenseChoicesProps, 
     }
 
     radioChoice = (text: string, link: string) => (
-        <span>{text} <a //className="black-link"
-                        href={link}
-                        target="_blank">
-            <i className="fas fa-info-circle"/>
-        </a>
-        </span>
+        <span><a className="external-link" href={link} target="_blank"><i className="fas fa-external-link-square-alt"/></a> {text}</span>
     )
 
     render() {
@@ -78,8 +73,7 @@ class LicenseChoices extends Component<WrappedFieldProps & LicenseChoicesProps, 
         }
         const containsAllChoices = this.props.choices.length < this.state.showCount
 
-        const radioChoices = <RadioChoicesInput {...this.props} choices={actualChoices}/>
-        // TODO style the <a/> properly
+        const radioChoices = <RadioChoicesInput {...this.props} divClassName="radio-choices" choices={actualChoices}/>
         const showMore = !containsAllChoices && <a className="show-more" onClick={this.showMoreLicenses}>show more...</a>
 
         return (

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -43,7 +43,7 @@ const DepositTableRow = ({ depositId, deposit, deleting, deleteDeposit }: Deposi
     const editable = isEditable(deposit)
 
     const title = editable
-        ? <Link className="black-link" to={depositFormRoute(depositId)}><Enterable title={deposit.title}/></Link>
+        ? <Link style={{color: "black"}} to={depositFormRoute(depositId)}><Enterable title={deposit.title}/></Link>
         : <Enterable title={deposit.title}/>
 
     const isDeleting = deleting && deleting.deleting

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -43,7 +43,7 @@ const DepositTableRow = ({ depositId, deposit, deleting, deleteDeposit }: Deposi
     const editable = isEditable(deposit)
 
     const title = editable
-        ? <Link to={depositFormRoute(depositId)}><Enterable title={deposit.title}/></Link>
+        ? <Link className="black-link" to={depositFormRoute(depositId)}><Enterable title={deposit.title}/></Link>
         : <Enterable title={deposit.title}/>
 
     const isDeleting = deleting && deleting.deleting

--- a/src/main/typescript/lib/formComponents/RadioChoices.tsx
+++ b/src/main/typescript/lib/formComponents/RadioChoices.tsx
@@ -16,11 +16,12 @@
 import * as React from "react"
 import { WrappedFieldProps } from "redux-form"
 import asField from "./FieldHOC"
+import { Component } from "react"
 
 interface RadioChoice {
     name?: string
     title: any
-    value: string
+    value: string | JSX.Element
 }
 
 interface RadioProps {


### PR DESCRIPTION
Fixes EASY-1601

#### When applied it will
* replace the license dropdown with a multi tiered radio choice

@DANS-KNAW/easy for review

#### Images
_The depositor has chosen for CC-BY-4.0, saved and reloaded the deposit._
![image](https://user-images.githubusercontent.com/5938204/42311813-ffbf88a0-803e-11e8-9063-92e67a10a737.png)

_When clicking on 'show more...', it will show the first 3 licenses (+ selected license if it is not contained)._
![image](https://user-images.githubusercontent.com/5938204/42311831-08c47e60-803f-11e8-8044-854fdf43af12.png)

_When clicking again on 'show more...', it will show all licenses._
![image](https://user-images.githubusercontent.com/5938204/42311847-12bc9196-803f-11e8-8d1b-8bbb20bcdba5.png)

_The arrow before each license will lead to a new tab with the license._
![image](https://user-images.githubusercontent.com/5938204/42312083-b476a508-803f-11e8-80de-c225cd693265.png)