### PR TITLE
EASY-1615: Move red minus buttons next to the fields

### DIFF
--- a/src/main/resources/css/form.css
+++ b/src/main/resources/css/form.css
@@ -20,16 +20,9 @@
 
 .input-element .title-label {
     padding-top: 5px;
+    margin-bottom: 0;
     font-weight: bold;
     color: #444;
-}
-
-.input-element .title-label.multi-field-label {
-    padding-top: 11px;
-}
-
-.input-element .title-label.text-array-label {
-    padding-top: 6px;
 }
 
 .input-element .value-label {
@@ -42,17 +35,18 @@
     font-size: 14px;
 }
 
-.input-element .add-button {
+.input-element .remove-and-add-buttons {
     align-self: flex-end;
 }
 
-.input-element .add-button > button {
+.input-element .remove-and-add-buttons > button {
     padding-top: 8px;
     padding-bottom: 7px;
-    float: right;
+    /*float: right;*/
+    float: left;
 }
 
-.input-element .remove-button:disabled {
+.input-element .remove-and-add-buttons > button:disabled {
     opacity: 0.25;
 }
 
@@ -82,6 +76,12 @@
 .input-element > .text-array {
     padding-top: 5px;
     color: #444;
+}
+
+.input-element > .text-array > .container,
+.input-element > .text-array > .container > .row {
+    padding: 0;
+    margin: 0;
 }
 
 .input-element .form-row {

--- a/src/main/resources/css/form.css
+++ b/src/main/resources/css/form.css
@@ -42,7 +42,6 @@
 .input-element .remove-and-add-buttons > button {
     padding-top: 8px;
     padding-bottom: 7px;
-    /*float: right;*/
     float: left;
 }
 

--- a/src/main/typescript/components/form/FoldableCard.tsx
+++ b/src/main/typescript/components/form/FoldableCard.tsx
@@ -52,8 +52,6 @@ class FoldableCard extends Component<FoldableCardProps & FoldableCardInputProps>
     render() {
         const { title, required, open, children } = this.props
 
-        const x = `${open ? "" : "closed"} card mb-3`.trim()
-
         return (
             <div className={`${open ? "" : "closed"} card mb-3`.trim()}>
                 <h6 className="card-header row ml-0 mr-0 bg-primary text-white" onClick={this.collapseCard}>

--- a/src/main/typescript/components/form/FoldableCard.tsx
+++ b/src/main/typescript/components/form/FoldableCard.tsx
@@ -52,12 +52,10 @@ class FoldableCard extends Component<FoldableCardProps & FoldableCardInputProps>
     render() {
         const { title, required, open, children } = this.props
 
+        const x = `${open ? "" : "closed"} card mb-3`.trim()
+
         return (
-            <div className={[
-                open ? "" : "closed",
-                "card",
-                "container pl-0 pr-0 ml-15 mr-15 mb-3",
-            ].join(" ").trim()}>
+            <div className={`${open ? "" : "closed"} card mb-3`.trim()}>
                 <h6 className="card-header row ml-0 mr-0 bg-primary text-white" onClick={this.collapseCard}>
                     <div className="col-11 order-1 col-md-9 order-md-1 pl-0 pr-0">{title}</div>
                     {required

--- a/src/main/typescript/components/form/parts/ArchaeologySpecificMetadataForm.tsx
+++ b/src/main/typescript/components/form/parts/ArchaeologySpecificMetadataForm.tsx
@@ -34,32 +34,26 @@ interface ArchaeologySpecificMetadataFormProps {
     abrPeriodeTemporals: DropdownList
 }
 
-const ArchaeologySpecificMetadataForm = ({abrComplexSubjects, abrPeriodeTemporals} : ArchaeologySpecificMetadataFormProps) => (
-    <div className="container pl-0 pr-0">
-        <div className="row form-group input-element">
-            <RepeatableField name="archisNrs"
-                             label="Archis zaakidentificatie"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+const ArchaeologySpecificMetadataForm = ({ abrComplexSubjects, abrPeriodeTemporals }: ArchaeologySpecificMetadataFormProps) => (
+    <>
+        <RepeatableField name="archisNrs"
+                         label="Archis zaakidentificatie"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="subjectsAbrComplex"
-                             label="Subject (ABR complex)"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={AbrComplexSubjectFieldArray(abrComplexSubjects)}/>
-        </div>
+        <RepeatableField name="subjectsAbrComplex"
+                         label="Subject (ABR complex)"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={AbrComplexSubjectFieldArray(abrComplexSubjects)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="temporalCoveragesAbr"
-                             label="Temporal (ABR period)"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={AbrPeriodeTemporalsFieldArray(abrPeriodeTemporals)}/>
-        </div>
-    </div>
+        <RepeatableField name="temporalCoveragesAbr"
+                         label="Temporal (ABR period)"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={AbrPeriodeTemporalsFieldArray(abrPeriodeTemporals)}/>
+    </>
 )
 
 const mapStateToProps = (state: AppState) => ({

--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -81,193 +81,155 @@ interface BasicInformationFormProps {
 }
 
 const BasicInformationForm = ({ depositId, languages, contributorIds, contributorRoles, audiences, identifiers, relations, dates }: BasicInformationFormProps) => (
-    <div className="container pl-0 pr-0">
-        <div className="row form-group input-element">
-            <Field name="doi"
-                   label="Digital Object Identifier"
-                   depositId={depositId}
-                   component={DoiField}/>
-        </div>
+    <>
+        <Field name="doi"
+               label="Digital Object Identifier"
+               depositId={depositId}
+               component={DoiField}/>
 
-        <div className="row form-group input-element">
-            <Field name="languageOfDescription"
-                   label="Language of description"
-                   withEmptyDefault
-                   component={LanguageField(languages)}/>
-        </div>
+        <Field name="languageOfDescription"
+               label="Language of description"
+               withEmptyDefault
+               component={LanguageField(languages)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="titles"
-                             label="Title"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+        <RepeatableField name="titles"
+                         label="Title"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="alternativeTitles"
-                             label="Alternative title"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+        <RepeatableField name="alternativeTitles"
+                         label="Alternative title"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <Field name="description"
-                   label="Description"
-                   rows={5}
-                   maxRows={15}
-                   component={TextArea}/>
-        </div>
+        <Field name="description"
+               label="Description"
+               rows={5}
+               maxRows={15}
+               component={TextArea}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="creators"
-                             label="Creator"
-                             empty={emptyContributor}
-                             fieldNames={[
-                                 (name: string) => `${name}.titles`, // 0
-                                 (name: string) => `${name}.initials`, // 1
-                                 (name: string) => `${name}.insertions`, // 2
-                                 (name: string) => `${name}.surname`, // 3
-                                 (name: string) => `${name}.ids`, // 4
-                                 (name: string) => `${name}.role`, // 5
-                                 (name: string) => `${name}.organization`, // 6
-                             ]}
-                             component={ContributorFields(contributorIds, contributorRoles)}/>
-        </div>
+        <RepeatableField name="creators"
+                         label="Creator"
+                         empty={emptyContributor}
+                         fieldNames={[
+                             (name: string) => `${name}.titles`, // 0
+                             (name: string) => `${name}.initials`, // 1
+                             (name: string) => `${name}.insertions`, // 2
+                             (name: string) => `${name}.surname`, // 3
+                             (name: string) => `${name}.ids`, // 4
+                             (name: string) => `${name}.role`, // 5
+                             (name: string) => `${name}.organization`, // 6
+                         ]}
+                         component={ContributorFields(contributorIds, contributorRoles)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="contributors"
-                             label="Contributors"
-                             empty={emptyContributor}
-                             fieldNames={[
-                                 (name: string) => `${name}.titles`, // 0
-                                 (name: string) => `${name}.initials`, // 1
-                                 (name: string) => `${name}.insertions`, // 2
-                                 (name: string) => `${name}.surname`, // 3
-                                 (name: string) => `${name}.ids`, // 4
-                                 (name: string) => `${name}.role`, // 5
-                                 (name: string) => `${name}.organization`, // 6
-                             ]}
-                             component={ContributorFields(contributorIds, contributorRoles)}/>
-        </div>
+        <RepeatableField name="contributors"
+                         label="Contributors"
+                         empty={emptyContributor}
+                         fieldNames={[
+                             (name: string) => `${name}.titles`, // 0
+                             (name: string) => `${name}.initials`, // 1
+                             (name: string) => `${name}.insertions`, // 2
+                             (name: string) => `${name}.surname`, // 3
+                             (name: string) => `${name}.ids`, // 4
+                             (name: string) => `${name}.role`, // 5
+                             (name: string) => `${name}.organization`, // 6
+                         ]}
+                         component={ContributorFields(contributorIds, contributorRoles)}/>
 
-        <div className="row form-group input-element">
-            <Field name="dateCreated"
-                   label="Date created"
-                   todayButton="Today"
-                   showYearDropdown
-                   yearDropdownItemNumber={10}
-                   scrollableYearDropdown
-                   maxDate={moment()}
-                   component={DatePickerField}/>
-        </div>
+        <Field name="dateCreated"
+               label="Date created"
+               todayButton="Today"
+               showYearDropdown
+               yearDropdownItemNumber={10}
+               scrollableYearDropdown
+               maxDate={moment()}
+               component={DatePickerField}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="audiences"
-                             label="Audience"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={AudienceFieldArray(audiences)}/>
-        </div>
+        <RepeatableField name="audiences"
+                         label="Audience"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={AudienceFieldArray(audiences)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="subjects"
-                             label="Subject"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+        <RepeatableField name="subjects"
+                         label="Subject"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="alternativeIdentifiers"
-                             label="Alternative identifier"
-                             empty={emptySchemedValue}
-                             fieldNames={[
-                                 (name: string) => `${name}.scheme`,
-                                 (name: string) => `${name}.value`,
-                             ]}
-                             component={AlternativeIdentifierFieldArray(identifiers)}/>
-        </div>
+        <RepeatableField name="alternativeIdentifiers"
+                         label="Alternative identifier"
+                         empty={emptySchemedValue}
+                         fieldNames={[
+                             (name: string) => `${name}.scheme`,
+                             (name: string) => `${name}.value`,
+                         ]}
+                         component={AlternativeIdentifierFieldArray(identifiers)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="relatedIdentifiers"
-                             label="Relations"
-                             empty={emptyQualifiedSchemedValue}
-                             fieldNames={[
-                                 (name: string) => `${name}.qualifier`,
-                                 (name: string) => `${name}.scheme`,
-                                 (name: string) => `${name}.value`,
-                             ]}
-                             component={RelatedIdentifierFieldArray(relations, identifiers)}/>
-        </div>
+        <RepeatableField name="relatedIdentifiers"
+                         label="Relations"
+                         empty={emptyQualifiedSchemedValue}
+                         fieldNames={[
+                             (name: string) => `${name}.qualifier`,
+                             (name: string) => `${name}.scheme`,
+                             (name: string) => `${name}.value`,
+                         ]}
+                         component={RelatedIdentifierFieldArray(relations, identifiers)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="relations"
-                             label=""
-                             empty={emptyRelation}
-                             fieldNames={[
-                                 (name: string) => `${name}.qualifier`,
-                                 (name: string) => `${name}.title`,
-                                 (name: string) => `${name}.url`,
-                             ]}
-                             component={RelationFieldArray(relations)}/>
-        </div>
+        <RepeatableField name="relations"
+                         label=""
+                         empty={emptyRelation}
+                         fieldNames={[
+                             (name: string) => `${name}.qualifier`,
+                             (name: string) => `${name}.title`,
+                             (name: string) => `${name}.url`,
+                         ]}
+                         component={RelationFieldArray(relations)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="languagesOfFilesIso639"
-                             label="Language of files (ISO 639)"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={LanguageFieldArray(languages)}/>
-        </div>
+        <RepeatableField name="languagesOfFilesIso639"
+                         label="Language of files (ISO 639)"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={LanguageFieldArray(languages)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="languagesOfFiles"
-                             label="Language of files"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+        <RepeatableField name="languagesOfFiles"
+                         label="Language of files"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="datesIso8601"
-                             label="Date (ISO 8601)"
-                             empty={emptyQualifiedDate}
-                             fieldNames={[
-                                 (name: string) => `${name}.qualifier`,
-                                 (name: string) => `${name}.value`,
-                             ]}
-                             component={IsoDateFieldArray(dates)}/>
-        </div>
+        <RepeatableField name="datesIso8601"
+                         label="Date (ISO 8601)"
+                         empty={emptyQualifiedDate}
+                         fieldNames={[
+                             (name: string) => `${name}.qualifier`,
+                             (name: string) => `${name}.value`,
+                         ]}
+                         component={IsoDateFieldArray(dates)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="dates"
-                             label="Date"
-                             empty={emptyQualifiedStringDate}
-                             fieldNames={[
-                                 (name: string) => `${name}.qualifier`,
-                                 (name: string) => `${name}.value`,
-                             ]}
-                             component={DateFieldArray(dates)}/>
-        </div>
+        <RepeatableField name="dates"
+                         label="Date"
+                         empty={emptyQualifiedStringDate}
+                         fieldNames={[
+                             (name: string) => `${name}.qualifier`,
+                             (name: string) => `${name}.value`,
+                         ]}
+                         component={DateFieldArray(dates)}/>
 
-        <div className="row form-group input-element">
-            <Field name="source"
-                   label="Source"
-                   rows={5}
-                   maxRows={15}
-                   component={TextArea}/>
-        </div>
+        <Field name="source"
+               label="Source"
+               rows={5}
+               maxRows={15}
+               component={TextArea}/>
 
-        <div className="row form-group input-element">
-            <Field name="instructionsForReuse"
-                   label="Instructions for reuse"
-                   rows={5}
-                   maxRows={15}
-                   component={TextArea}/>
-        </div>
-    </div>
+        <Field name="instructionsForReuse"
+               label="Instructions for reuse"
+               rows={5}
+               maxRows={15}
+               component={TextArea}/>
+    </>
 )
 
 const mapStateToProps = (state: AppState) => ({

--- a/src/main/typescript/components/form/parts/DepositLicenseForm.tsx
+++ b/src/main/typescript/components/form/parts/DepositLicenseForm.tsx
@@ -27,7 +27,7 @@ const mustBeChecked = (value?: any) => value && value === true
     : "Accept the license agreement before submitting this dataset"
 
 const DepositLicenseForm = () => (
-    <div className="container pl-0 pr-0">
+    <>
         <div className="row form-group input-element mb-0">
             <p>
                 {/* TODO fill in the correct href in the <a> */}
@@ -74,7 +74,7 @@ const DepositLicenseForm = () => (
                    component={Checkbox}
                    validate={[mustBeChecked]}/>
         </div>
-    </div>
+    </>
 )
 
 export default DepositLicenseForm

--- a/src/main/typescript/components/form/parts/LicenseAndAccessForm.tsx
+++ b/src/main/typescript/components/form/parts/LicenseAndAccessForm.tsx
@@ -43,53 +43,43 @@ interface LicenseAndAccessFormProps {
 }
 
 const LicenseAndAccessForm = ({ licenses, contributorIds }: LicenseAndAccessFormProps) => (
-    <div className="container pl-0 pr-0">
-        <div className="row form-group input-element">
-            <RepeatableField name="rightsHolders"
-                             label="Rightsholders"
-                             empty={emptyContributor}
-                             fieldNames={[
-                                 (name: string) => `${name}.titles`, // 0
-                                 (name: string) => `${name}.initials`, // 1
-                                 (name: string) => `${name}.insertions`, // 2
-                                 (name: string) => `${name}.surname`, // 3
-                                 (name: string) => `${name}.ids`, // 4
-                                 (name: string) => `${name}.role`, // 5 - NOTE: not used in this instance, but still necessary for a correct implementation
-                                 (name: string) => `${name}.organization`, // 6
-                             ]}
-                             component={RightsholderFields(contributorIds)}/>
-        </div>
+    <>
+        <RepeatableField name="rightsHolders"
+                         label="Rightsholders"
+                         empty={emptyContributor}
+                         fieldNames={[
+                             (name: string) => `${name}.titles`, // 0
+                             (name: string) => `${name}.initials`, // 1
+                             (name: string) => `${name}.insertions`, // 2
+                             (name: string) => `${name}.surname`, // 3
+                             (name: string) => `${name}.ids`, // 4
+                             (name: string) => `${name}.role`, // 5 - NOTE: not used in this instance, but still necessary for a correct implementation
+                             (name: string) => `${name}.organization`, // 6
+                         ]}
+                         component={RightsholderFields(contributorIds)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="publishers"
-                             label="Publishers"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+        <RepeatableField name="publishers"
+                         label="Publishers"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <Field name="accessRights"
-                   label="Access rights"
-                   component={AccessRightsField}/>
-        </div>
+        <Field name="accessRights"
+               label="Access rights"
+               component={AccessRightsField}/>
 
-        <div className="row form-group input-element">
-            <Field name="license"
-                   label="License"
-                   withEmptyDefault
-                   component={LicenseField(licenses)}/>
-        </div>
+        <Field name="license"
+               label="License"
+               withEmptyDefault
+               component={LicenseField(licenses)}/>
 
-        <div className="row form-group input-element">
-            <Field name="dateAvailable"
-                   label="Date available"
-                   todayButton="Today"
-                   minDate={moment()}
-                   maxDate={moment().add(2, "years")}
-                   component={DatePickerField}/>
-        </div>
-    </div>
+        <Field name="dateAvailable"
+               label="Date available"
+               todayButton="Today"
+               minDate={moment()}
+               maxDate={moment().add(2, "years")}
+               component={DatePickerField}/>
+    </>
 )
 
 const mapStateToProps = (state: AppState) => ({

--- a/src/main/typescript/components/form/parts/MessageForDataManagerForm.tsx
+++ b/src/main/typescript/components/form/parts/MessageForDataManagerForm.tsx
@@ -22,16 +22,15 @@ export interface MessageForDataManagerFormData {
 }
 
 const MessageForDataManagerForm = () => (
-    <div className="container pl-0 pr-0">
-        <div className="row form-group input-element">
-            <Field name="messageForDataManager"
-                   rows={10}
-                   maxRows={20}
-                   maxHeight={500}
-                   label="Message for the data manager"
-                   component={TextArea}/>
-        </div>
-    </div>
+    <>
+        {/* TODO this field must be wider */}
+        <Field name="messageForDataManager"
+               rows={10}
+               maxRows={20}
+               maxHeight={500}
+               label="Message for the data manager"
+               component={TextArea}/>
+    </>
 )
 
 export default MessageForDataManagerForm

--- a/src/main/typescript/components/form/parts/PrivacySensitiveDataForm.tsx
+++ b/src/main/typescript/components/form/parts/PrivacySensitiveDataForm.tsx
@@ -15,7 +15,7 @@
  */
 import * as React from "react"
 import { Field } from "redux-form"
-import {RadioChoicesInput} from "../../../lib/formComponents/RadioChoices"
+import { RadioChoicesInput } from "../../../lib/formComponents/RadioChoices"
 import { PrivacySensitiveDataValue } from "../../../lib/metadata/PrivacySensitiveData"
 
 export interface PrivacySensitiveDataFormData {
@@ -26,28 +26,26 @@ export interface PrivacySensitiveDataFormData {
 const oneSelected = (value?: any) => value ? undefined : "you need to select one of these choices"
 
 const PrivacySensitiveDataForm = () => (
-    <div className="container pl-0 pr-0">
+    <>
         <div className="row form-group input-element">
             {/* TODO provide a proper text */}
             Hier een tekst met uitleg over de privacy sensitive data en waarom men hier verplicht een keuze moet maken.
         </div>
 
-        <div className="row form-group input-element">
-            <Field name="privacySensitiveDataPresent"
-                   choices={[
-                       {
-                           title: PrivacySensitiveDataValue.YES,
-                           value: "YES, this dataset does contain personal data (please contact DANS)",
-                       },
-                       {
-                           title: PrivacySensitiveDataValue.NO,
-                           value: "NO, this dataset does not contain personal data",
-                       },
-                   ]}
-                   component={RadioChoicesInput}
-                   validate={[oneSelected]}/>
-        </div>
-    </div>
+        <Field name="privacySensitiveDataPresent"
+               choices={[
+                   {
+                       title: PrivacySensitiveDataValue.YES,
+                       value: "YES, this dataset does contain personal data (please contact DANS)",
+                   },
+                   {
+                       title: PrivacySensitiveDataValue.NO,
+                       value: "NO, this dataset does not contain personal data",
+                   },
+               ]}
+               component={RadioChoicesInput}
+               validate={[oneSelected]}/>
+    </>
 )
 
 export default PrivacySensitiveDataForm

--- a/src/main/typescript/components/form/parts/TemporalAndSpatialCoverageForm.tsx
+++ b/src/main/typescript/components/form/parts/TemporalAndSpatialCoverageForm.tsx
@@ -40,64 +40,54 @@ interface TemporalAndSpatialCoverageFormProps {
     spatialCoveragesIso: DropdownList
 }
 
-const TemporalAndSpatialCoverageForm = ({spatialCoordinates, spatialCoveragesIso}: TemporalAndSpatialCoverageFormProps) => (
-    <div className="container pl-0 pr-0">
-        <div className="row form-group input-element">
-            <RepeatableField name="temporalCoverages"
-                             label="Temporal coverage"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+const TemporalAndSpatialCoverageForm = ({ spatialCoordinates, spatialCoveragesIso }: TemporalAndSpatialCoverageFormProps) => (
+    <>
+        <RepeatableField name="temporalCoverages"
+                         label="Temporal coverage"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="spatialPoints"
-                             label="Spatial point"
-                             empty={emptyPoint}
-                             fieldNames={[
-                                 (name: string) => `${name}.scheme`,
-                                 (name: string) => `${name}.x`,
-                                 (name: string) => `${name}.y`,
-                             ]}
-                             component={SpatialPointFieldArray(spatialCoordinates)}/>
-        </div>
+        <RepeatableField name="spatialPoints"
+                         label="Spatial point"
+                         empty={emptyPoint}
+                         fieldNames={[
+                             (name: string) => `${name}.scheme`,
+                             (name: string) => `${name}.x`,
+                             (name: string) => `${name}.y`,
+                         ]}
+                         component={SpatialPointFieldArray(spatialCoordinates)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="spatialBoxes"
-                             label="Spatial box"
-                             empty={emptyBox}
-                             fieldNames={[
-                                 (name: string) => `${name}.scheme`,
-                                 (name: string) => `${name}.north`,
-                                 (name: string) => `${name}.east`,
-                                 (name: string) => `${name}.south`,
-                                 (name: string) => `${name}.west`,
-                             ]}
-                             component={SpatialBoxFieldArray(spatialCoordinates)}/>
-        </div>
+        <RepeatableField name="spatialBoxes"
+                         label="Spatial box"
+                         empty={emptyBox}
+                         fieldNames={[
+                             (name: string) => `${name}.scheme`,
+                             (name: string) => `${name}.north`,
+                             (name: string) => `${name}.east`,
+                             (name: string) => `${name}.south`,
+                             (name: string) => `${name}.west`,
+                         ]}
+                         component={SpatialBoxFieldArray(spatialCoordinates)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="spatialCoverageIso3166"
-                             label="Spatial coverage (ISO 3166)"
-                             empty={emptySchemedValue}
-                             fieldNames={[
-                                 (name: string) => name,
-                             ]}
-                /*
-                 * values taken from https://nl.wikipedia.org/wiki/ISO_3166-1
-                 * use values ISO-3166-1 alpha-3
-                 */
-                             component={SpatialCoverageIso3166FieldArray(spatialCoveragesIso)}/>
-        </div>
+        <RepeatableField name="spatialCoverageIso3166"
+                         label="Spatial coverage (ISO 3166)"
+                         empty={emptySchemedValue}
+                         fieldNames={[
+                             (name: string) => name,
+                         ]}
+            /*
+             * values taken from https://nl.wikipedia.org/wiki/ISO_3166-1
+             * use values ISO-3166-1 alpha-3
+             */
+                         component={SpatialCoverageIso3166FieldArray(spatialCoveragesIso)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="spatialCoverages"
-                             label="Spatial coverage"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
-    </div>
+        <RepeatableField name="spatialCoverages"
+                         label="Spatial coverage"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
+    </>
 )
 
 const mapStateToProps = (state: AppState) => ({

--- a/src/main/typescript/components/form/parts/UploadTypeForm.tsx
+++ b/src/main/typescript/components/form/parts/UploadTypeForm.tsx
@@ -55,47 +55,37 @@ const clarinChoices = [
 ]
 
 const UploadTypeForm = ({ dcmiTypes, imtFormats }: UploadTypeFormProps) => (
-    <div className="container pl-0 pr-0">
-        <div className="row form-group input-element">
-            <RepeatableField name="typesDCMI"
-                             label="Type (DCMI resource type)"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={DcmiTypesFieldArray(dcmiTypes)}/>
-        </div>
+    <>
+        <RepeatableField name="typesDCMI"
+                         label="Type (DCMI resource type)"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={DcmiTypesFieldArray(dcmiTypes)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="types"
-                             label="Types"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+        <RepeatableField name="types"
+                         label="Types"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="formatsMediaType"
-                             label=" Format (internet media type)"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={ImtFormatsFieldArray(imtFormats)}/>
-        </div>
+        <RepeatableField name="formatsMediaType"
+                         label=" Format (internet media type)"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={ImtFormatsFieldArray(imtFormats)}/>
 
-        <div className="row form-group input-element">
-            <RepeatableField name="formats"
-                             label="Formats"
-                             empty={emptyString}
-                             fieldNames={[(name: string) => name]}
-                             component={TextFieldArray}/>
-        </div>
+        <RepeatableField name="formats"
+                         label="Formats"
+                         empty={emptyString}
+                         fieldNames={[(name: string) => name]}
+                         component={TextFieldArray}/>
 
-        <div className="row form-group input-element">
-            <Field name="extraClarinMetadataPresent"
-                   label="Contains CLARIN metadata"
-                   choices={clarinChoices}
-                   component={RadioChoices}
-                   validate={[oneSelected]}/>
-        </div>
-    </div>
+        <Field name="extraClarinMetadataPresent"
+               label="Contains CLARIN metadata"
+               choices={clarinChoices}
+               component={RadioChoices}
+               validate={[oneSelected]}/>
+    </>
 )
 
 const mapStateToProps = (state: AppState) => ({

--- a/src/main/typescript/components/form/parts/basicInformation/DoiField.tsx
+++ b/src/main/typescript/components/form/parts/basicInformation/DoiField.tsx
@@ -38,10 +38,10 @@ interface DoiFieldStoreFunctions {
 type DoiFieldProps = WrappedFieldProps & DoiFieldInputArguments & DoiFieldStoreArguments & DoiFieldStoreFunctions
 
 const DoiField = ({ input, meta, label, depositId, fetchDoi, fetchDoiState: { fetchingDoi, fetchDoiError } }: DoiFieldProps) => (
-    <>
-        <label className="col-12 col-md-3 pl-0 title-label" htmlFor={input.name}>{label}</label>
+    <div className="row form-group input-element mb-4">
+        <label className="col-12 col-md-3 pl-0 title-label">{label}</label>
         {input.value
-            ? <label className="col-12 col-md-9 value-label" id={input.name}>{input.value}</label>
+            ? <label className="col-12 col-md-7 value-label" id={input.name}>{input.value}</label>
             : fetchDoiError
                 ? <ReloadAlert key="fetchMetadataError" reload={() => fetchDoi(depositId)}>
                     An error occurred: {fetchDoiError}. Cannot create a new DOI.
@@ -51,7 +51,7 @@ const DoiField = ({ input, meta, label, depositId, fetchDoi, fetchDoiState: { fe
                           onClick={() => fetchDoi(depositId)}
                           disabled={fetchingDoi}>Reserve DOI</button>
         }
-    </>
+    </div>
 )
 
 const mapStateToProps = (state: AppState) => ({

--- a/src/main/typescript/lib/formComponents/AddButton.tsx
+++ b/src/main/typescript/lib/formComponents/AddButton.tsx
@@ -20,13 +20,11 @@ interface AddButtonProps {
 }
 
 const AddButton = ({ onClick }: AddButtonProps) => (
-    <div className="col-12 col-md-1 mb-2 pl-0 pr-0 add-button">
-        <button type="button"
-                className="input-group-text bg-success text-light"
-                onClick={onClick}>
-            <i className="fas fa-plus-square"/>
-        </button>
-    </div>
+    <button type="button"
+            className="input-group-text bg-success text-light"
+            onClick={onClick}>
+        <i className="fas fa-plus-square"/>
+    </button>
 )
 
 export default AddButton

--- a/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
@@ -28,52 +28,32 @@ const ContributorIdArray = (idValues: DropdownListEntry[]) => (
     function <T>({ fields, fieldNames, empty }: FieldArrayProps<T>) {
         return (
             <>
-                <div className="col-12 col-md-9 pl-0 pr-0 text-array">
-                    {fields.map((name: string, index: number) => (
-                        <div className="form-row" key={`${name}.${index}`}>
-                            <div className="col col-md-3 mb-2">
-                                <Field name={fieldNames[0](name)}
-                                       choices={idValues}
-                                       withEmptyDefault
-                                       component={DropdownFieldInput}/>
-                            </div>
-
-                            <div className="col col-md-9 mb-2">
-                                <div className="input-group">
-                                    <Field name={fieldNames[1](name)}
-                                           placeholder="ID"
-                                           component={TextField}/>
-                                    <RemoveButton onClick={() => fields.remove(index)}
-                                                  disabled={fields.length <= 1}/>
-                                </div>
-                            </div>
+                {fields.map((name, index) => (
+                    <div className="form-row mb-2" key={`${name}.${index}`}>
+                        <div className="col-12 col-md-3 pl-0">
+                            <Field name={fieldNames[0](name)}
+                                   choices={idValues}
+                                   withEmptyDefault
+                                   component={DropdownFieldInput}/>
                         </div>
-                    ))}
-                </div>
-                <AddButton onClick={() => fields.push(empty)}/>
+
+                        <div className="col-12 col-md-6 pr-2">
+                            <Field name={fieldNames[1](name)}
+                                   placeholder="ID"
+                                   component={TextField}/>
+                        </div>
+
+                        <div className="col-2 pl-0 pr-0 remove-and-add-buttons">
+                            <RemoveButton onClick={() => fields.remove(index)}
+                                          className="mr-2"
+                                          disabled={fields.length <= 1}/>
+                            {index === fields.length - 1 && <AddButton onClick={() => fields.push(empty)}/>}
+                        </div>
+                    </div>
+                ))}
             </>
         )
     }
-)
-
-interface ContributorIdRowsProps {
-    idName: string
-    idValues: DropdownListEntry[]
-}
-
-const ContributorIdRows = ({ idName, idValues }: ContributorIdRowsProps) => (
-    <div className="container pl-0 pr-0">
-        <div className="row ml-0 mr-0">
-            <RepeatableField name={idName}
-                             label="Contributor Ids"
-                             empty={emptySchemedValue}
-                             fieldNames={[
-                                 (name: string) => `${name}.scheme`,
-                                 (name: string) => `${name}.value`,
-                             ]}
-                             component={ContributorIdArray(idValues)}/>
-        </div>
-    </div>
 )
 
 interface NameProps {
@@ -112,32 +92,12 @@ const Name = ({ titleName, initialsName, insertionsName, surnameName }: NameProp
     </>
 )
 
-interface OrganizationProps {
-    organizationName: string
-    deleteDisabled: boolean
-
-    onDelete: () => void
-}
-
-const Organization = ({ organizationName, onDelete, deleteDisabled }: OrganizationProps) => (
-    <>
-        <label>Organization</label>
-        <div className="input-group">
-            <Field name={organizationName}
-                   placeholder="organization"
-                   component={TextField}/>
-            <RemoveButton onClick={onDelete}
-                          disabled={deleteDisabled}/>
-        </div>
-    </>
-)
-
 interface ContributorFieldProps extends InnerComponentProps {
     idValues: DropdownListEntry[]
     roleValues?: DropdownListEntry[]
 }
 
-const ContributorField = ({ names, onDelete, deleteDisabled, idValues, roleValues }: ContributorFieldProps) => (
+const ContributorField = ({ names, idValues, roleValues }: ContributorFieldProps) => (
     <div className="border rounded contributor p-2 mb-4">
         <div className="form-row">
             <Name titleName={names[0]}
@@ -156,14 +116,21 @@ const ContributorField = ({ names, onDelete, deleteDisabled, idValues, roleValue
             </div>
         </div>}
 
-        <ContributorIdRows idName={names[4]}
-                           idValues={idValues}/>
+        <RepeatableField name={names[4]}
+                         label="Contributor Ids"
+                         empty={emptySchemedValue}
+                         fieldNames={[
+                             (name: string) => `${name}.scheme`,
+                             (name: string) => `${name}.value`,
+                         ]}
+                         component={ContributorIdArray(idValues)}/>
 
         <div className="form-row">
             <div className="col form-group">
-                <Organization organizationName={names[6]}
-                              onDelete={onDelete}
-                              deleteDisabled={deleteDisabled}/>
+                <label>Organization</label>
+                <Field name={names[6]}
+                       placeholder="organization"
+                       component={TextField}/>
             </div>
         </div>
     </div>

--- a/src/main/typescript/lib/formComponents/DropDownFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/DropDownFieldArray.tsx
@@ -17,7 +17,6 @@ import * as React from "react"
 import { Field } from "redux-form"
 import { DropdownFieldInput } from "./DropDownField"
 import { DropdownListEntry } from "../../model/DropdownLists"
-import RemoveButton from "./RemoveButton"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 
 interface DropdownFieldProps extends InnerComponentProps {
@@ -26,17 +25,13 @@ interface DropdownFieldProps extends InnerComponentProps {
     withEmptyDefault?: boolean
 }
 
-const DropdownField = ({ names, label, onDelete, deleteDisabled, choices, withEmptyDefault }: DropdownFieldProps) => (
-    <div className="input-group mb-2 mr-2">
-        <Field name={names[0]}
-               label={label}
-               className="custom-select"
-               choices={choices}
-               withEmptyDefault={withEmptyDefault}
-               component={DropdownFieldInput}/>
-        <RemoveButton onClick={onDelete}
-                      disabled={deleteDisabled}/>
-    </div>
+const DropdownField = ({ names, label, choices, withEmptyDefault }: DropdownFieldProps) => (
+    <Field name={names[0]}
+           label={label}
+           className="custom-select"
+           choices={choices}
+           withEmptyDefault={withEmptyDefault}
+           component={DropdownFieldInput}/>
 )
 
 export default asFieldArray(DropdownField)

--- a/src/main/typescript/lib/formComponents/FieldArrayHOC.tsx
+++ b/src/main/typescript/lib/formComponents/FieldArrayHOC.tsx
@@ -17,36 +17,44 @@ import * as React from "react"
 import AddButton from "./AddButton"
 import { ComponentType } from "react"
 import { FieldArrayProps } from "./RepeatableField"
+import RemoveButton from "./RemoveButton"
 
 export interface InnerComponentProps {
     names: string[]
-    deleteDisabled: boolean
-
-    onDelete: () => void
 }
 
-const asFieldArray = (InnerComponent: ComponentType<InnerComponentProps>) => {
-    return function <T>(props: FieldArrayProps<T> & any) {
+const isFirstIndex: (index: number) => boolean = index => index === 0
+
+const isLastIndex: <T>(arr: T[], index: number) => boolean = (arr, index) => index === arr.length - 1
+
+const asFieldArray = (InnerComponent: ComponentType<InnerComponentProps>) => (
+    function <T>(props: FieldArrayProps<T> & any) {
         const { fields, fieldNames, empty, label } = props
 
-        return (
-            <>
-                <label className={"col-12 col-md-3 pl-0 title-label multi-field-label"}>{label || ""}</label>
-                <div className="col-12 col-md-8 pl-0 pr-0 text-array">
-                    {fields.map((name: string, index: number) => {
-                        const innerProps = {
-                            ...(props),
-                            names: fieldNames.map((f: (name: string) => string) => f(name)),
-                            onDelete: () => fields.remove(index),
-                            deleteDisabled: fields.length <= 1,
-                        }
-                        return <InnerComponent {...innerProps} key={`${name}.${index}`}/>
-                    })}
+        return fields.map((name: string, index: number) => {
+            const lastIndex = isLastIndex(fields, index)
+
+            return (
+                <div className={`row form-group input-element ${lastIndex ? "mb-4" : "mb-2"}`} key={`${name}.${index}`}>
+                    <label className="col-12 col-md-3 pl-0 pr-0 title-label">
+                        {isFirstIndex(index) && label ? label : ""}
+                    </label>
+
+                    <div className="col-12 col-md-8 pl-0 pr-2">
+                        <InnerComponent {...props}
+                                        names={fieldNames.map((f: (name: string) => string) => f(name))}/>
+                    </div>
+
+                    <div className="col-1 pl-0 pr-0 remove-and-add-buttons">
+                        <RemoveButton disabled={fields.length <= 1}
+                                      className="mr-2"
+                                      onClick={() => fields.remove(index)}/>
+                        {lastIndex && <AddButton onClick={() => fields.push(empty)}/>}
+                    </div>
                 </div>
-                <AddButton onClick={() => fields.push(empty)}/>
-            </>
-        )
+            )
+        })
     }
-}
+)
 
 export default asFieldArray

--- a/src/main/typescript/lib/formComponents/FieldHOC.tsx
+++ b/src/main/typescript/lib/formComponents/FieldHOC.tsx
@@ -23,15 +23,15 @@ interface InnerComponentProps {
 }
 
 const asField = (InnerComponent: ComponentType<InnerComponentProps & any>) => (props: WrappedFieldProps & any) => {
-    const { htmlFor, label } = props
+    const { label } = props
 
     return (
-        <>
-            <label className="col-12 col-md-3 pl-0 title-label text-array-label" htmlFor={htmlFor}>{label || ""}</label>
-            <div className="col-12 col-md-8 pl-0 pr-0">
+        <div className="row form-group input-element mb-4">
+            <label className="col-12 col-md-3 pl-0 title-label">{label || ""}</label>
+            <div className="col-12 col-md-8 pl-0 pr-2">
                 <InnerComponent {...props}/>
             </div>
-        </>
+        </div>
     )
 }
 

--- a/src/main/typescript/lib/formComponents/QualifiedSchemedTextFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/QualifiedSchemedTextFieldArray.tsx
@@ -18,7 +18,6 @@ import { Field } from "redux-form"
 import TextField from "./TextField"
 import { DropdownFieldInput } from "./DropDownField"
 import { DropdownListEntry } from "../../model/DropdownLists"
-import RemoveButton from "./RemoveButton"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 
 interface QualifiedSchemedTextFieldProps extends InnerComponentProps {
@@ -29,9 +28,9 @@ interface QualifiedSchemedTextFieldProps extends InnerComponentProps {
     withEmptySchemeDefault?: boolean
 }
 
-const QualifiedSchemedTextFieldArray = ({ names, label, onDelete, deleteDisabled, qualifierValues, withEmptyQualifierDefault, schemeValues, withEmptySchemeDefault }: QualifiedSchemedTextFieldProps) => (
+const QualifiedSchemedTextFieldArray = ({ names, label, qualifierValues, withEmptyQualifierDefault, schemeValues, withEmptySchemeDefault }: QualifiedSchemedTextFieldProps) => (
     <div className="form-row">
-        <div className="col col-md-3">
+        <div className="col col-md-4">
             <Field name={names[0]}
                    label="Qualifier"
                    choices={qualifierValues}
@@ -45,15 +44,11 @@ const QualifiedSchemedTextFieldArray = ({ names, label, onDelete, deleteDisabled
                    withEmptyDefault={withEmptySchemeDefault}
                    component={DropdownFieldInput}/>
         </div>
-        <div className="col col-md-6">
-            <div className="input-group mb-2 mr-2">
-                <Field name={names[2]}
-                       label="Value" // TODO is label necessary anyway?
-                       placeholder={label}
-                       component={TextField}/>
-                <RemoveButton onClick={onDelete}
-                              disabled={deleteDisabled}/>
-            </div>
+        <div className="col col-md-5">
+            <Field name={names[2]}
+                   label="Value" // TODO is label necessary anyway?
+                   placeholder={label}
+                   component={TextField}/>
         </div>
     </div>
 )

--- a/src/main/typescript/lib/formComponents/RadioChoices.tsx
+++ b/src/main/typescript/lib/formComponents/RadioChoices.tsx
@@ -16,7 +16,6 @@
 import * as React from "react"
 import { WrappedFieldProps } from "redux-form"
 import asField from "./FieldHOC"
-import { Component } from "react"
 
 interface RadioChoice {
     name?: string

--- a/src/main/typescript/lib/formComponents/RelationFieldArrayElement.tsx
+++ b/src/main/typescript/lib/formComponents/RelationFieldArrayElement.tsx
@@ -18,7 +18,6 @@ import { AnchorHTMLAttributes } from "react"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 import { DropdownListEntry } from "../../model/DropdownLists"
 import LabeledTextField from "./LabeledTextField"
-import RemoveButton from "./RemoveButton"
 import { DropdownFieldInput } from "./DropDownField"
 import { Field, WrappedFieldProps } from "redux-form"
 import * as validUrl from "valid-url"
@@ -40,16 +39,16 @@ interface RelationFieldArrayProps extends InnerComponentProps {
     get: (index: number) => any
 }
 
-const RelationFieldArrayElement = ({ names, onDelete, deleteDisabled, schemeValues }: RelationFieldArrayProps) => (
+const RelationFieldArrayElement = ({ names, schemeValues }: RelationFieldArrayProps) => (
     <div className="relation">
         <div className="form-row">
-            <div className="col col-md-3 mb-1">
+            <div className="col col-md-4 mb-1">
                 <Field name={names[0]}
                        label="Qualifier"
                        choices={schemeValues}
                        component={DropdownFieldInput}/>
             </div>
-            <div className="col col-md-9 input-group mb-1">
+            <div className="col col-md-8 input-group mb-1">
                 <Field name={names[1]}
                        label="Title"
                        placeholder="Title"
@@ -59,19 +58,16 @@ const RelationFieldArrayElement = ({ names, onDelete, deleteDisabled, schemeValu
         </div>
 
         <div className="form-row">
-            <div className="col col-md-3 mb-2"/>
-            <div className="col col-md-9 input-group mb-2">
-                <div className="input-group">
+            <div className="col col-md-4"/>
+            <div className="col col-md-8 input-group">
+                <Field name={names[2]}
+                       label="Url"
+                       placeholder="Url"
+                       labelWidth={44}
+                       component={LabeledTextField}/>
+                <div className="input-group-append">
                     <Field name={names[2]}
-                           label="Url"
-                           placeholder="Url"
-                           labelWidth={44}
-                           component={LabeledTextField}/>
-                    <div className="input-group-append">
-                        <Field name={names[2]}
-                               component={RelationValidateButton}/>
-                    </div>
-                    <RemoveButton onClick={onDelete} disabled={deleteDisabled}/>
+                           component={RelationValidateButton}/>
                 </div>
             </div>
         </div>

--- a/src/main/typescript/lib/formComponents/RemoveButton.tsx
+++ b/src/main/typescript/lib/formComponents/RemoveButton.tsx
@@ -17,19 +17,18 @@ import * as React from "react"
 
 interface RemoveButtonProps {
     disabled: boolean
+    className?: string
 
     onClick: () => void
 }
 
-const RemoveButton = ({ onClick, disabled }: RemoveButtonProps) => (
-    <div className="input-group-append">
-        <button type="button"
-                className="input-group-text bg-danger text-light remove-button"
-                onClick={onClick}
-                disabled={disabled}>
-            <i className="fas fa-minus-square"/>
-        </button>
-    </div>
+const RemoveButton = ({ onClick, disabled, className }: RemoveButtonProps) => (
+    <button type="button"
+            className={`input-group-text bg-danger text-light ${className}`.trim()}
+            onClick={onClick}
+            disabled={disabled}>
+        <i className="fas fa-minus-square"/>
+    </button>
 )
 
 export default RemoveButton

--- a/src/main/typescript/lib/formComponents/SchemedBoxArray.tsx
+++ b/src/main/typescript/lib/formComponents/SchemedBoxArray.tsx
@@ -18,14 +18,13 @@ import { Field } from "redux-form"
 import { DropdownFieldInput } from "./DropDownField"
 import { DropdownListEntry } from "../../model/DropdownLists"
 import LabeledTextField from "./LabeledTextField"
-import RemoveButton from "./RemoveButton"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 
 interface SchemedBoxProps extends InnerComponentProps {
     schemeValues: DropdownListEntry[]
 }
 
-const SchemedBox = ({ names, onDelete, deleteDisabled, schemeValues }: SchemedBoxProps) => (
+const SchemedBox = ({ names, schemeValues }: SchemedBoxProps) => (
     <>
         <div className="form-row">
             <div className="col mb-1">
@@ -40,6 +39,7 @@ const SchemedBox = ({ names, onDelete, deleteDisabled, schemeValues }: SchemedBo
                        label="North"
                        placeholder="upper bound"
                        type="number"
+                       labelWidth={55}
                        component={LabeledTextField}/>
             </div>
             <div className="col input-group mb-1">
@@ -47,29 +47,28 @@ const SchemedBox = ({ names, onDelete, deleteDisabled, schemeValues }: SchemedBo
                        label="East"
                        placeholder="right bound"
                        type="number"
+                       labelWidth={50}
                        component={LabeledTextField}/>
             </div>
         </div>
 
         <div className="form-row">
-            <div className="col mb-2"/>
-            <div className="col input-group mb-2">
+            <div className="col"/>
+            <div className="col input-group">
                 <Field name={names[3]}
                        label="South"
                        placeholder="lower bound"
                        type="number"
+                       labelWidth={55}
                        component={LabeledTextField}/>
             </div>
-            <div className="col">
-                <div className="input-group mb-2 mr-2">
-                    <Field name={names[4]}
-                           label="West"
-                           placeholder="left bound"
-                           type="number"
-                           component={LabeledTextField}/>
-                    <RemoveButton onClick={onDelete}
-                                  disabled={deleteDisabled}/>
-                </div>
+            <div className="col input-group">
+                <Field name={names[4]}
+                       label="West"
+                       placeholder="left bound"
+                       type="number"
+                       labelWidth={50}
+                       component={LabeledTextField}/>
             </div>
         </div>
     </>

--- a/src/main/typescript/lib/formComponents/SchemedDatePickerArray.tsx
+++ b/src/main/typescript/lib/formComponents/SchemedDatePickerArray.tsx
@@ -16,7 +16,6 @@
 import * as React from "react"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 import { Field } from "redux-form"
-import RemoveButton from "./RemoveButton"
 import { DatePickerInput } from "./DatePickerField"
 import { DropdownListEntry } from "../../model/DropdownLists"
 import { DropdownFieldInput } from "./DropDownField"

--- a/src/main/typescript/lib/formComponents/SchemedDatePickerArray.tsx
+++ b/src/main/typescript/lib/formComponents/SchemedDatePickerArray.tsx
@@ -27,36 +27,32 @@ interface SchemedDatePickerArrayProps extends InnerComponentProps {
     withEmptyDefault?: boolean
 }
 
-const SchemedDatePickerArray = ({ names, label, onDelete, deleteDisabled, schemeValues, withEmptyDefault }: SchemedDatePickerArrayProps) => (
+const SchemedDatePickerArray = ({ names, label, schemeValues, withEmptyDefault }: SchemedDatePickerArrayProps) => (
     <div className="form-row">
-        <div className="col col-md-3">
+        <div className="col col-md-4">
             <Field name={names[0]}
                    label="Scheme"
                    choices={schemeValues}
                    withEmptyDefault={withEmptyDefault}
                    component={DropdownFieldInput}/>
         </div>
-        <div className="col col-md-9">
-            <div className="input-group mb-2 mr-2">
-                {/*
-                  * In contrast to other form fields, we have the '.form-control' wrapped around the Field
-                  * DatePickerInput wraps a DatePicker that is not managed by us. Therefore we cannot add
-                  * the '.form-control' at the appropriate location in the DOM tree.
-                  * Wrapping the Field in this way, together with the '.date-picker-field' allows us to
-                  * change some rules in form.css such that this field matches our overall look-and-feel.
-                  */}
-                <div className="form-control date-picker-field">
-                    <Field name={names[1]}
-                           label="Value"
-                           todayButton="Today"
-                           showYearDropdown
-                           yearDropdownItemNumber={5}
-                           scrollableYearDropdown
-                           placeholder={label}
-                           component={DatePickerInput}/>
-                </div>
-                <RemoveButton onClick={onDelete}
-                              disabled={deleteDisabled}/>
+        <div className="col col-md-8 input-group">
+            {/*
+              * In contrast to other form fields, we have the '.form-control' wrapped around the Field
+              * DatePickerInput wraps a DatePicker that is not managed by us. Therefore we cannot add
+              * the '.form-control' at the appropriate location in the DOM tree.
+              * Wrapping the Field in this way, together with the '.date-picker-field' allows us to
+              * change some rules in form.css such that this field matches our overall look-and-feel.
+              */}
+            <div className="form-control date-picker-field">
+                <Field name={names[1]}
+                       label="Value"
+                       todayButton="Today"
+                       showYearDropdown
+                       yearDropdownItemNumber={5}
+                       scrollableYearDropdown
+                       placeholder={label}
+                       component={DatePickerInput}/>
             </div>
         </div>
     </div>

--- a/src/main/typescript/lib/formComponents/SchemedPointArray.tsx
+++ b/src/main/typescript/lib/formComponents/SchemedPointArray.tsx
@@ -18,14 +18,13 @@ import { Field } from "redux-form"
 import { DropdownFieldInput } from "./DropDownField"
 import { DropdownListEntry } from "../../model/DropdownLists"
 import LabeledTextField from "./LabeledTextField"
-import RemoveButton from "./RemoveButton"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 
 interface SchemedPointProps extends InnerComponentProps {
     schemeValues: DropdownListEntry[]
 }
 
-const SchemedPoint = ({ names, onDelete, deleteDisabled, schemeValues }: SchemedPointProps) => (
+const SchemedPoint = ({ names, schemeValues }: SchemedPointProps) => (
     <div className="form-row">
         <div className="col">
             <Field name={names[0]}
@@ -34,23 +33,19 @@ const SchemedPoint = ({ names, onDelete, deleteDisabled, schemeValues }: Schemed
                    withEmptyDefault
                    component={DropdownFieldInput}/>
         </div>
-        <div className="col input-group mb-2">
+        <div className="col input-group">
             <Field name={names[1]}
                    label="X"
                    placeholder="coordinate"
                    type="number"
                    component={LabeledTextField}/>
         </div>
-        <div className="col">
-            <div className="input-group mb-2 mr-2">
-                <Field name={names[2]}
-                       label="Y"
-                       placeholder="coordinate"
-                       type="number"
-                       component={LabeledTextField}/>
-                <RemoveButton onClick={onDelete}
-                              disabled={deleteDisabled}/>
-            </div>
+        <div className="col input-group">
+            <Field name={names[2]}
+                   label="Y"
+                   placeholder="coordinate"
+                   type="number"
+                   component={LabeledTextField}/>
         </div>
     </div>
 )

--- a/src/main/typescript/lib/formComponents/SchemedTextFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/SchemedTextFieldArray.tsx
@@ -18,7 +18,6 @@ import { Field } from "redux-form"
 import TextField from "./TextField"
 import { DropdownFieldInput } from "./DropDownField"
 import { DropdownListEntry } from "../../model/DropdownLists"
-import RemoveButton from "./RemoveButton"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 
 interface SchemedTextFieldProps extends InnerComponentProps {
@@ -27,24 +26,20 @@ interface SchemedTextFieldProps extends InnerComponentProps {
     withEmptyDefault?: boolean
 }
 
-const SchemedTextField = ({ names, label, onDelete, deleteDisabled, schemeValues, withEmptyDefault }: SchemedTextFieldProps) => (
+const SchemedTextField = ({ names, label, schemeValues, withEmptyDefault }: SchemedTextFieldProps) => (
     <div className="form-row">
-        <div className="col col-md-3">
+        <div className="col col-md-4">
             <Field name={names[0]}
                    label="Scheme"
                    choices={schemeValues}
                    withEmptyDefault={withEmptyDefault}
                    component={DropdownFieldInput}/>
         </div>
-        <div className="col col-md-9">
-            <div className="input-group mb-2 mr-2">
-                <Field name={names[1]}
-                       label="Value"
-                       placeholder={label}
-                       component={TextField}/>
-                <RemoveButton onClick={onDelete}
-                              disabled={deleteDisabled}/>
-            </div>
+        <div className="col col-md-8">
+            <Field name={names[1]}
+                   label="Value"
+                   placeholder={label}
+                   component={TextField}/>
         </div>
     </div>
 )

--- a/src/main/typescript/lib/formComponents/TextFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/TextFieldArray.tsx
@@ -23,15 +23,11 @@ interface TextFieldProps extends InnerComponentProps {
     label: string
 }
 
-const TextField = ({ names, label, onDelete, deleteDisabled }: TextFieldProps) => (
-    <div className="input-group mb-2 mr-2">
-        <Field name={names[0]}
-               label={label}
-               placeholder={label}
-               component={InnerTextField }/>
-        <RemoveButton onClick={onDelete}
-                      disabled={deleteDisabled}/>
-    </div>
+const TextField = ({ names, label }: TextFieldProps) => (
+    <Field name={names[0]}
+           label={label}
+           placeholder={label}
+           component={InnerTextField}/>
 )
 
 export default asFieldArray(TextField)

--- a/src/main/typescript/lib/formComponents/TextFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/TextFieldArray.tsx
@@ -16,7 +16,6 @@
 import * as React from "react"
 import InnerTextField from "./TextField"
 import { Field } from "redux-form"
-import RemoveButton from "./RemoveButton"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 
 interface TextFieldProps extends InnerComponentProps {


### PR DESCRIPTION
Fixes EASY-1615

#### When applied it will
* move the buttons outside the fields
* do some reformatting of the form (`div`s, `container`s, `row`s, etc.)

@DANS-KNAW/easy for review

![image](https://user-images.githubusercontent.com/5938204/42639292-f6724dbc-85ef-11e8-80b9-2891a506d304.png)

![image](https://user-images.githubusercontent.com/5938204/42639275-ee1f78d8-85ef-11e8-9104-0cb23ebac5ff.png)