### PR TITLE
EASY-1595: Make each row of the deposit overview table fully clickable

### DIFF
--- a/src/main/resources/css/depositOverviewPage.css
+++ b/src/main/resources/css/depositOverviewPage.css
@@ -31,8 +31,13 @@
     text-align: center;
 }
 
+.editable_table_row {
+    cursor: default;
+}
+
 .not_editable_table_row {
     color: #919191;
+    cursor: not-allowed;
 }
 
 .not_editable_table_row #enter_dataset {

--- a/src/main/typescript/actions/depositOverviewActions.ts
+++ b/src/main/typescript/actions/depositOverviewActions.ts
@@ -20,8 +20,6 @@ import { deleteDepositURL, listDepositsURL, newDepositURL } from "../constants/s
 import { DepositId, Deposits } from "../model/Deposits"
 import { Action } from "redux"
 import { depositsConverter, newDepositConverter } from "../lib/deposits/deposits"
-import { push, RouterAction } from "react-router-redux"
-import { depositFormRoute } from "../constants/clientRoutes"
 
 export const fetchDeposits: () => FetchAction<Deposits> = () => ({
     type: DepositOverviewConstants.FETCH_DEPOSITS,

--- a/src/main/typescript/actions/depositOverviewActions.ts
+++ b/src/main/typescript/actions/depositOverviewActions.ts
@@ -20,6 +20,8 @@ import { deleteDepositURL, listDepositsURL, newDepositURL } from "../constants/s
 import { DepositId, Deposits } from "../model/Deposits"
 import { Action } from "redux"
 import { depositsConverter, newDepositConverter } from "../lib/deposits/deposits"
+import { push, RouterAction } from "react-router-redux"
+import { depositFormRoute } from "../constants/clientRoutes"
 
 export const fetchDeposits: () => FetchAction<Deposits> = () => ({
     type: DepositOverviewConstants.FETCH_DEPOSITS,

--- a/src/main/typescript/components/overview/DepositOverview.tsx
+++ b/src/main/typescript/components/overview/DepositOverview.tsx
@@ -17,13 +17,19 @@ import * as React from "react"
 import { Component } from "react"
 import { connect } from "react-redux"
 import { AppState } from "../../model/AppState"
-import { DepositId, DepositOverviewState, Deposits } from "../../model/Deposits"
+import { Deposit, DepositId, DepositOverviewState, Deposits, DepositState } from "../../model/Deposits"
 import { cleanDeposits, deleteDeposit, fetchDeposits } from "../../actions/depositOverviewActions"
 import { FetchAction, PromiseAction } from "../../lib/redux"
-import { Action } from "redux"
+import { Action, Dispatch } from "redux"
 import DepositTableHead from "./DepositTableHead"
 import DepositTableRow from "./DepositTableRow"
 import { Alert, CloseableWarning, ReloadAlert } from "../Errors"
+import { depositFormRoute } from "../../constants/clientRoutes"
+import { push, RouterAction } from "react-router-redux"
+
+function isEditable({ state }: Deposit): boolean {
+    return state === DepositState.DRAFT || state === DepositState.REJECTED
+}
 
 interface DepositOverviewProps {
     deposits: DepositOverviewState
@@ -31,6 +37,7 @@ interface DepositOverviewProps {
     fetchDeposits: () => FetchAction<Deposits>
     cleanDeposits: () => Action
     deleteDeposit: (depositId: DepositId) => PromiseAction<void>
+    enterDeposit: (editable: Boolean, depositId: DepositId) => RouterAction
 }
 
 class DepositOverview extends Component<DepositOverviewProps> {
@@ -104,17 +111,18 @@ class DepositOverview extends Component<DepositOverviewProps> {
     }
 
     private renderTable() {
-        const { deposits: { deposits, deleting }, deleteDeposit } = this.props
+        const { deposits: { deposits, deleting }, deleteDeposit, enterDeposit } = this.props
 
         return (
             <table className="table table-hover deposit_table">
                 <DepositTableHead/>
                 <tbody>{Object.keys(deposits).map(depositId =>
                     <DepositTableRow key={depositId}
-                                     depositId={depositId}
                                      deposit={deposits[depositId]}
                                      deleting={deleting[depositId]}
-                                     deleteDeposit={() => deleteDeposit(depositId)}/>,
+                                     deleteDeposit={() => deleteDeposit(depositId)}
+                                     editable={isEditable(deposits[depositId])}
+                                     enterDeposit={() => enterDeposit(isEditable(deposits[depositId]), depositId)}/>,
                 )}</tbody>
             </table>
         )
@@ -125,4 +133,11 @@ const mapStateToProps = (state: AppState) => ({
     deposits: state.deposits,
 })
 
-export default connect(mapStateToProps, { fetchDeposits, cleanDeposits, deleteDeposit })(DepositOverview)
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+    fetchDeposits: () => dispatch(fetchDeposits()),
+    cleanDeposits: () => dispatch(cleanDeposits()),
+    deleteDeposit: (depositId: DepositId) => dispatch(deleteDeposit(depositId)),
+    enterDeposit: (editable: Boolean, depositId: DepositId) => editable ? dispatch(push(depositFormRoute(depositId))) : null
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(DepositOverview)

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -55,12 +55,12 @@ class DepositTableRow extends Component<DepositTableRowProps> {
             </button>
 
         return (
-            <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ")} onClick={enterDeposit}>
+            <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ")}>
                 {/* these column sizes need to match with the sizes in DepositTableHead */}
-                <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row">{title}</td>
-                <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2">{dateFormat(deposit.date, "yyyy-mm-dd")}</td>
-                <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3">{deposit.state}</td>
-                <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4">{deposit.stateDescription}</td>
+                <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row" onClick={enterDeposit}>{title}</td>
+                <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2" onClick={enterDeposit}>{dateFormat(deposit.date, "yyyy-mm-dd")}</td>
+                <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3" onClick={enterDeposit}>{deposit.state}</td>
+                <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4" onClick={enterDeposit}>{deposit.stateDescription}</td>
                 <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5"
                     id="actions_cell">{deleteButton}</td>
             </tr>

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -15,13 +15,8 @@
  */
 import * as React from "react"
 import * as dateFormat from "dateformat"
-import { DeleteState, Deposit, DepositId, DepositState } from "../../model/Deposits"
-import { Link } from "react-router-dom"
-import { depositFormRoute } from "../../constants/clientRoutes"
-
-function isEditable({ state }: Deposit): boolean {
-    return state === DepositState.DRAFT || state === DepositState.REJECTED
-}
+import { DeleteState, Deposit } from "../../model/Deposits"
+import { Component } from "react"
 
 interface EnterableProps {
     title: string
@@ -32,46 +27,46 @@ const Enterable = ({ title }: EnterableProps) => (
 )
 
 interface DepositTableRowProps {
-    depositId: DepositId
     deposit: Deposit
     deleting?: DeleteState
-
     deleteDeposit: () => void
+    editable: Boolean
+    enterDeposit: () =>  void
 }
 
-const DepositTableRow = ({ depositId, deposit, deleting, deleteDeposit }: DepositTableRowProps) => {
-    const editable = isEditable(deposit)
+class DepositTableRow extends Component<DepositTableRowProps> {
+    constructor(props: DepositTableRowProps) {
+        super(props)
+    }
 
-    const title = editable
-        ? <Link style={{color: "black"}} to={depositFormRoute(depositId)}><Enterable title={deposit.title}/></Link>
-        : <Enterable title={deposit.title}/>
+    render() {
+        const { deposit, deleting, deleteDeposit, editable, enterDeposit } = this.props
+        const title = <Enterable title={deposit.title}/>
+        const isDeleting = deleting && deleting.deleting
+        const deleteButton = editable &&
+            <button key="delete"
+                    className="close icon"
+                    style={{ float: "unset" }}
+                    disabled={isDeleting}
+                    onClick={deleteDeposit}>
+                {isDeleting
+                    ? <i className="fas fa-sync-alt fa-spin"/>
+                    : <i className="fas fa-trash-alt"/>}
+            </button>
 
-    const isDeleting = deleting && deleting.deleting
-    const deleteButton = editable &&
-        <button key="delete"
-                className="close icon"
-                style={{ float: "unset" }}
-                disabled={isDeleting}
-                onClick={deleteDeposit}>
-            {isDeleting
-                ? <i className="fas fa-sync-alt fa-spin"/>
-                : <i className="fas fa-trash-alt"/>}
-        </button>
+        return (
+            <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ")} onClick={enterDeposit}>
+                {/* these column sizes need to match with the sizes in DepositTableHead */}
+                <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row">{title}</td>
+                <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2">{dateFormat(deposit.date, "yyyy-mm-dd")}</td>
+                <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3">{deposit.state}</td>
+                <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4">{deposit.stateDescription}</td>
+                <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5"
+                    id="actions_cell">{deleteButton}</td>
+            </tr>
+        )
+    }
 
-    return (
-        <tr className={[
-            "row",
-            editable ? "" : "not_editable_table_row",
-        ].join(" ")}>
-            {/* these column sizes need to match with the sizes in DepositTableHead */}
-            <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row">{title}</td>
-            <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2">{dateFormat(deposit.date, "yyyy-mm-dd")}</td>
-            <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3">{deposit.state}</td>
-            <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4">{deposit.stateDescription}</td>
-            <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5"
-                id="actions_cell">{deleteButton}</td>
-        </tr>
-    )
 }
 
 export default DepositTableRow

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -16,7 +16,6 @@
 import * as React from "react"
 import * as dateFormat from "dateformat"
 import { DeleteState, Deposit } from "../../model/Deposits"
-import { Component } from "react"
 
 interface EnterableProps {
     title: string
@@ -31,42 +30,39 @@ interface DepositTableRowProps {
     deleting?: DeleteState
     deleteDeposit: () => void
     editable: Boolean
-    enterDeposit: () =>  void
+    enterDeposit: () => void
 }
 
-class DepositTableRow extends Component<DepositTableRowProps> {
-    constructor(props: DepositTableRowProps) {
-        super(props)
-    }
+const DepositTableRow = ({ deposit, deleting, deleteDeposit, editable, enterDeposit }: DepositTableRowProps) => {
 
-    render() {
-        const { deposit, deleting, deleteDeposit, editable, enterDeposit } = this.props
-        const title = <Enterable title={deposit.title}/>
-        const isDeleting = deleting && deleting.deleting
-        const deleteButton = editable &&
-            <button key="delete"
-                    className="close icon"
-                    style={{ float: "unset" }}
-                    disabled={isDeleting}
-                    onClick={deleteDeposit}>
-                {isDeleting
-                    ? <i className="fas fa-sync-alt fa-spin"/>
-                    : <i className="fas fa-trash-alt"/>}
-            </button>
+    const title = <Enterable title={deposit.title}/>
+    const isDeleting = deleting && deleting.deleting
+    const deleteButton = editable &&
+        <button key="delete"
+                className="close icon"
+                style={{ float: "unset" }}
+                disabled={isDeleting}
+                onClick={deleteDeposit}>
+            {isDeleting
+                ? <i className="fas fa-sync-alt fa-spin"/>
+                : <i className="fas fa-trash-alt"/>}
+        </button>
 
-        return (
-            <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ")}>
-                {/* these column sizes need to match with the sizes in DepositTableHead */}
-                <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row" onClick={enterDeposit}>{title}</td>
-                <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2" onClick={enterDeposit}>{dateFormat(deposit.date, "yyyy-mm-dd")}</td>
-                <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3" onClick={enterDeposit}>{deposit.state}</td>
-                <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4" onClick={enterDeposit}>{deposit.stateDescription}</td>
-                <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5"
-                    id="actions_cell">{deleteButton}</td>
-            </tr>
-        )
-    }
-
+    return (
+        <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ")}>
+            {/* these column sizes need to match with the sizes in DepositTableHead */}
+            <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row"
+                onClick={enterDeposit}>{title}</td>
+            <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2"
+                onClick={enterDeposit}>{dateFormat(deposit.date, "yyyy-mm-dd")}</td>
+            <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3"
+                onClick={enterDeposit}>{deposit.state}</td>
+            <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4"
+                onClick={enterDeposit}>{deposit.stateDescription}</td>
+            <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5"
+                id="actions_cell">{deleteButton}</td>
+        </tr>
+    )
 }
 
 export default DepositTableRow

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -28,8 +28,9 @@ const Enterable = ({ title }: EnterableProps) => (
 interface DepositTableRowProps {
     deposit: Deposit
     deleting?: DeleteState
-    deleteDeposit: () => void
     editable: Boolean
+
+    deleteDeposit: () => void
     enterDeposit: () => void
 }
 


### PR DESCRIPTION
Fixes EASY-1595

#### When applied it will
* make each row of the deposit overview table fully clickable

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..


![deposit_ui_3](https://user-images.githubusercontent.com/15029430/42936635-e80fd78c-8b4c-11e8-8c93-35930ad8b981.jpeg)
![deposit_ui_1](https://user-images.githubusercontent.com/15029430/42936629-e333a270-8b4c-11e8-9d6c-48281a74507f.jpeg)
![deposit_ui_2](https://user-images.githubusercontent.com/15029430/42936617-db1a27f8-8b4c-11e8-955e-f80c9b0ae1f7.jpeg)