### PR TITLE
EASY-1595: stop propagation on delete button to not enter the deposit as well

### DIFF
--- a/src/main/resources/css/depositOverviewPage.css
+++ b/src/main/resources/css/depositOverviewPage.css
@@ -32,7 +32,7 @@
 }
 
 .editable_table_row {
-    cursor: default;
+    cursor: pointer;
 }
 
 .not_editable_table_row {

--- a/src/main/typescript/components/overview/DepositOverview.tsx
+++ b/src/main/typescript/components/overview/DepositOverview.tsx
@@ -20,7 +20,7 @@ import { AppState } from "../../model/AppState"
 import { Deposit, DepositId, DepositOverviewState, Deposits, DepositState } from "../../model/Deposits"
 import { cleanDeposits, deleteDeposit, fetchDeposits } from "../../actions/depositOverviewActions"
 import { FetchAction, PromiseAction, ThunkAction } from "../../lib/redux"
-import { Action, Dispatch } from "redux"
+import { Action } from "redux"
 import DepositTableHead from "./DepositTableHead"
 import DepositTableRow from "./DepositTableRow"
 import { Alert, CloseableWarning, ReloadAlert } from "../Errors"
@@ -110,7 +110,10 @@ class DepositOverview extends Component<DepositOverviewProps> {
             </Alert>
     }
 
-    deleteDeposit = (depositId: DepositId) => () => this.props.deleteDeposit(depositId)
+    deleteDeposit = (depositId: DepositId) => (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation()
+        this.props.deleteDeposit(depositId)
+    }
 
     enterDeposit = (editable: boolean, depositId: DepositId) => () => editable && this.props.enterDeposit(depositId)
 

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -30,7 +30,7 @@ interface DepositTableRowProps {
     deleting?: DeleteState
     editable: Boolean
 
-    deleteDeposit: () => void
+    deleteDeposit: (e: React.MouseEvent<HTMLButtonElement>) => void
     enterDeposit: () => void
 }
 
@@ -50,16 +50,13 @@ const DepositTableRow = ({ deposit, deleting, deleteDeposit, editable, enterDepo
         </button>
 
     return (
-        <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ")}>
+        <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ")}
+            onClick={enterDeposit}>
             {/* these column sizes need to match with the sizes in DepositTableHead */}
-            <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row"
-                onClick={enterDeposit}>{title}</td>
-            <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2"
-                onClick={enterDeposit}>{dateFormat(deposit.date, "yyyy-mm-dd")}</td>
-            <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3"
-                onClick={enterDeposit}>{deposit.state}</td>
-            <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4"
-                onClick={enterDeposit}>{deposit.stateDescription}</td>
+            <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row">{title}</td>
+            <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2">{dateFormat(deposit.date, "yyyy-mm-dd")}</td>
+            <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3">{deposit.state}</td>
+            <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4">{deposit.stateDescription}</td>
             <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5"
                 id="actions_cell">{deleteButton}</td>
         </tr>


### PR DESCRIPTION
Follow-up on EASY-1595 and #68

When @vesaakerman and I were working on this issue before, we found that when the `onClick` event was placed on the whole row, and when clicking the delete button, the delete event would also trigger the 'enter deposit' event. Hence @vesaakerman made each **cell** clickable (with exception for the _action cell_), rather than the whole row. However, the solution we should taken back then is to catch the delete event in the callback and call [`.stopPropagation()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation).

@DANS-KNAW/easy for review