### PR TITLE
EASY-1717 remove group-access

### DIFF
--- a/src/main/resources/css/form.css
+++ b/src/main/resources/css/form.css
@@ -158,10 +158,6 @@
     margin-bottom: 6px;
 }
 
-.input-element .accessrights-field .group-field {
-    align-self: flex-end;
-}
-
 .input-element .license-field .radio-choices .external-link {
     color: var(--dark);
 }

--- a/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
@@ -30,7 +30,6 @@ interface AccessRightsFieldProps {
 }
 
 const AccessRightsField = ({ userGroups, input, meta, label }: FieldProps & AccessRightsFieldProps) => {
-    const withUserGroups = userGroups.length > 0
 
     const choices = [
         {
@@ -42,11 +41,6 @@ const AccessRightsField = ({ userGroups, input, meta, label }: FieldProps & Acce
             value: "Restricted Access",
         },
     ]
-    if (withUserGroups)
-        choices.push({
-            title: AccessRightValue.GROUP_ACCESS,
-            value: "Group Access",
-        })
 
     return (
         <div className="form-row accessrights-field">
@@ -56,27 +50,10 @@ const AccessRightsField = ({ userGroups, input, meta, label }: FieldProps & Acce
                        choices={choices}
                        component={RadioChoicesInput}/>
             </div>
-            {withUserGroups && <div className="col col-md-4 group-field">
-                <Field name={`${input.name}.group`}
-                       choices={userGroups}
-                       withEmptyDefault={userGroups.length != 1}
-                       emptyDefault="Choose a group..."
-                       disabled={input.value.category !== AccessRightValue.GROUP_ACCESS}
-                       component={DropdownFieldInput}/>
-            </div>}
         </div>
     )
 }
 
-const mapStateToProps = (state: AppState) => ({
-    userGroups: state.user.groups.map(group => ({
-        key: group,
-        value: group,
-        displayValue: group,
-    })),
-})
-
 export default compose(
-    asField,
-    connect(mapStateToProps),
+    asField
 )(AccessRightsField)

--- a/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
@@ -15,21 +15,13 @@
  */
 import * as React from "react"
 import { compose } from "redux"
-import { connect } from "react-redux"
 import { Field } from "redux-form"
 import { AccessRightValue } from "../../../../lib/metadata/AccessRight"
-import { DropdownListEntry } from "../../../../model/DropdownLists"
-import { AppState } from "../../../../model/AppState"
 import asField from "../../../../lib/formComponents/FieldHOC"
-import { DropdownFieldInput } from "../../../../lib/formComponents/DropDownField"
 import { RadioChoicesInput } from "../../../../lib/formComponents/RadioChoices"
 import { FieldProps } from "../../../../lib/formComponents/ReduxFormUtils"
 
-interface AccessRightsFieldProps {
-    userGroups: DropdownListEntry[]
-}
-
-const AccessRightsField = ({ userGroups, input, meta, label }: FieldProps & AccessRightsFieldProps) => {
+const AccessRightsField = ({ input }: FieldProps ) => {
 
     const choices = [
         {

--- a/src/main/typescript/lib/metadata/AccessRight.ts
+++ b/src/main/typescript/lib/metadata/AccessRight.ts
@@ -17,15 +17,11 @@ import { clean } from "./misc"
 
 export interface AccessRight {
     category?: AccessRightValue
-    group?: string
 }
 
 export enum AccessRightValue {
     OPEN_ACCESS = "OPEN_ACCESS",
-    // OPEN_ACCESS_FOR_REGISTERED_USERS = "OPEN_ACCESS_FOR_REGISTERED_USERS",
-    GROUP_ACCESS = "GROUP_ACCESS",
     REQUEST_PERMISSION = "REQUEST_PERMISSION",
-    // NO_ACCESS = "NO_ACCESS",
 }
 
 function toAccessRight(value: string): AccessRightValue | undefined {
@@ -35,38 +31,15 @@ function toAccessRight(value: string): AccessRightValue | undefined {
 export const accessRightConverter: (ar: any) => AccessRight = ar => {
     const category = toAccessRight(ar.category)
     if (category)
-        switch (category) {
-            case AccessRightValue.GROUP_ACCESS:
-                if (!!ar.group)
-                    return {
-                        category: category,
-                        group: ar.group,
-                    }
-                else
-                    throw `Error in metadata: access right ${AccessRightValue.GROUP_ACCESS} has no 'group' defined`
-            default:
-                if (!!ar.group)
-                    throw `Error in metadata: access right is not ${AccessRightValue.GROUP_ACCESS} but has a 'group' defined`
-                else
-                    return {
-                        category: category,
-                    }
-
+        return {
+            category: category,
         }
     else
         throw `Error in metadata: no such access category: '${ar.category}'`
 }
 
 export const accessRightDeconverter: (ar: AccessRight) => any = ar => {
-    switch (ar.category) {
-        case AccessRightValue.GROUP_ACCESS:
-            return clean({
-                category: ar.category,
-                group: ar.group,
-            })
-        default:
-            return clean({
-                category: ar.category,
-            })
-    }
+    return clean({
+        category: ar.category,
+    })
 }

--- a/src/main/typescript/lib/metadata/Metadata.ts
+++ b/src/main/typescript/lib/metadata/Metadata.ts
@@ -99,7 +99,7 @@ export const metadataConverter: (input: any, dropDowns: DropdownLists) => Deposi
     const instructionsForReuse = input.instructionsForReuse && input.instructionsForReuse.join("\n\n")
     const accessRights = input.accessRights
         ? accessRightConverter(input.accessRights)
-        : { category: undefined, group: undefined }
+        : { category: undefined }
     const license = input.license
         ? licenseConverter(dropDowns.licenses.list)(input.license)
         : emptyString

--- a/src/main/typescript/lib/user/user.ts
+++ b/src/main/typescript/lib/user/user.ts
@@ -26,7 +26,6 @@ export const userConverter: (input: any) => UserDetails = input => {
         firstName: input.firstName || "",
         prefix: input.prefix || "",
         lastName: input.lastName || "",
-        groups: input.groups || [],
         displayName: displayName,
     }
 }

--- a/src/main/typescript/middleware/depositFormMiddleware.ts
+++ b/src/main/typescript/middleware/depositFormMiddleware.ts
@@ -18,26 +18,13 @@ import { DepositFormConstants, depositFormName, saveDraftResetTimeout } from "..
 import { push } from "react-router-redux"
 import { depositOverviewRoute } from "../constants/clientRoutes"
 import { saveDraftResetAction } from "../actions/depositFormActions"
-import { actionTypes, change } from "redux-form"
-import { AccessRightValue } from "../lib/metadata/AccessRight"
+import { change } from "redux-form"
 
 const fetchDoiProcessor: Middleware = ({ dispatch }: MiddlewareAPI) => (next: Dispatch) => action => {
     next(action)
 
     if (action.type === DepositFormConstants.FETCH_DOI_SUCCESS)
         dispatch(change(depositFormName, "doi", action.payload))
-}
-
-// make sure to reset the access right group when the category changes from GROUP_ACCESS to something else
-// the access right group can only be used with category=GROUP_ACCESS
-const resetAccessrightGroupOnCategoryChange: Middleware = ({ dispatch, getState }: MiddlewareAPI) => (next: Dispatch) => action => {
-    if (action.type === actionTypes.CHANGE && // only trigger on a redux-form CHANGE event ...
-        action.meta.field === "accessRights.category" && // ... that is caused by an 'accessRights.category' field ...
-        getState().form.depositForm.values.accessRights.category === AccessRightValue.GROUP_ACCESS && // ... whose previous value was GROUP_ACCESS ...
-        action.payload !== AccessRightValue.GROUP_ACCESS) // ... and whose new value will be something else than GROUP_ACCESS ...
-        dispatch(change(depositFormName, "accessRights.group", "")) // ... then reset the 'accessRights.category' field
-
-    next(action)
 }
 
 const saveTimer: Middleware = ({ dispatch }: MiddlewareAPI) => (next: Dispatch) => action => {
@@ -56,7 +43,6 @@ const submitReroute: Middleware = ({ dispatch }: MiddlewareAPI) => (next: Dispat
 
 export const depositFormMiddleware: Middleware[] = [
     fetchDoiProcessor,
-    resetAccessrightGroupOnCategoryChange,
     saveTimer,
     submitReroute,
 ]

--- a/src/main/typescript/model/UserDetails.ts
+++ b/src/main/typescript/model/UserDetails.ts
@@ -19,7 +19,6 @@ export interface UserDetails {
     firstName: string,
     prefix: string,
     lastName: string,
-    groups: string[],
     displayName: string,
 }
 
@@ -28,6 +27,5 @@ export const empty = {
     firstName: "",
     prefix: "",
     lastName: "",
-    groups: [],
     displayName: "",
 }

--- a/src/main/typescript/reducers/userReducer.ts
+++ b/src/main/typescript/reducers/userReducer.ts
@@ -26,7 +26,6 @@ export const userReducer: Reducer<UserDetails> = (state = empty, action) => {
                 firstName: action.payload.firstName,
                 lastName: action.payload.lastName,
                 prefix: action.payload.prefix,
-                groups: action.payload.groups,
                 username: action.payload.username,
             }
         }

--- a/src/test/typescript/lib/metadata/AccessRight.spec.ts
+++ b/src/test/typescript/lib/metadata/AccessRight.spec.ts
@@ -35,49 +35,9 @@ describe("AccessRight", () => {
             expect(accessRightConverter(input)).to.eql(expected)
         })
 
-        it("should fail when given an open-access with a group", () => {
-            const input = {
-                category: "OPEN_ACCESS",
-                group: "an unexpected group",
-            }
-            expect(() => accessRightConverter(input)).to
-                .throw("Error in metadata: access right is not GROUP_ACCESS but has a 'group' defined")
-        })
-
-        it("should convert a valid group-access", () => {
-            const input = {
-                category: "GROUP_ACCESS",
-                group: "my-group",
-            }
-            const expected = {
-                category: "GROUP_ACCESS",
-                group: "my-group",
-            }
-            expect(accessRightConverter(input)).to.eql(expected)
-        })
-
-        it("should fail when given a group-access without a group", () => {
-            const input = {
-                category: "GROUP_ACCESS",
-                // no group here
-            }
-            expect(() => accessRightConverter(input)).to
-                .throw("Error in metadata: access right GROUP_ACCESS has no 'group' defined")
-        })
-
-        it("should fail when no category is given", () => {
-            const input = {
-                // no category here
-                group: "my-group",
-            }
-            expect(() => accessRightConverter(input)).to
-                .throw("Error in metadata: no such access category: 'undefined'")
-        })
-
         it("should fail when an unknown category is given", () => {
             const input = {
                 category: "unknown-category",
-                group: "my-group",
             }
             expect(() => accessRightConverter(input)).to
                 .throw("Error in metadata: no such access category: 'unknown-category'")
@@ -86,7 +46,6 @@ describe("AccessRight", () => {
         it("should fail when an empty object is given", () => {
             const input = {
                 // no category here
-                // no group here
             }
             expect(() => accessRightConverter(input)).to
                 .throw("Error in metadata: no such access category: 'undefined'")
@@ -102,21 +61,6 @@ describe("AccessRight", () => {
         it("should convert an AccessRight with only a category into the correct external model", () => {
             expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS })).to
                 .eql({ category: "OPEN_ACCESS" })
-        })
-
-        it("should convert an AccessRight with both a group-access category and a group into the correct external model", () => {
-            expect(accessRightDeconverter({ category: AccessRightValue.GROUP_ACCESS, group: "my-group" })).to
-                .eql({ category: "GROUP_ACCESS", group: "my-group" })
-        })
-
-        it("should convert an AccessRight with an open-access category and a group into an external model with only the category", () => {
-            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS, group: "my-group" })).to
-                .eql({ category: AccessRightValue.OPEN_ACCESS })
-        })
-
-        it("should convert an AccessRight with only a group-access category into the correct external model", () => {
-            expect(accessRightDeconverter({ category: AccessRightValue.GROUP_ACCESS })).to
-                .eql({ category: AccessRightValue.GROUP_ACCESS })
         })
     })
 })

--- a/src/test/typescript/lib/user/user.spec.ts
+++ b/src/test/typescript/lib/user/user.spec.ts
@@ -28,14 +28,12 @@ describe("user", () => {
                 firstName: "First",
                 prefix: "the",
                 lastName: "Name",
-                groups: [ "group001", "group002"]
             }
             const expected: UserDetails = {
                 username: "user001",
                 firstName: "First",
                 prefix: "the",
                 lastName: "Name",
-                groups: [ "group001", "group002" ],
                 displayName: "First the Name",
             }
 
@@ -48,14 +46,12 @@ describe("user", () => {
                 firstName: undefined,
                 prefix: undefined,
                 lastName: undefined,
-                groups: undefined
             }
             const expected: UserDetails = {
                 username: "",
                 firstName: "",
                 prefix: "",
                 lastName: "",
-                groups: [],
                 displayName: "",
             }
 
@@ -68,14 +64,12 @@ describe("user", () => {
                 firstName: "",
                 prefix: "the",
                 lastName: "Name",
-                groups: [ "group001", "group002"]
             }
             const expected: UserDetails = {
                 username: "user001",
                 firstName: "",
                 prefix: "the",
                 lastName: "Name",
-                groups: [ "group001", "group002" ],
                 displayName: "the Name",
             }
 
@@ -88,14 +82,12 @@ describe("user", () => {
                 firstName: "First",
                 prefix: undefined,
                 lastName: "Name",
-                groups: [ "group001", "group002"]
             }
             const expected: UserDetails = {
                 username: "user001",
                 firstName: "First",
                 prefix: "",
                 lastName: "Name",
-                groups: [ "group001", "group002" ],
                 displayName: "First Name",
             }
 
@@ -108,14 +100,12 @@ describe("user", () => {
                 firstName: "First",
                 prefix: "the",
                 lastName: undefined,
-                groups: [ "group001", "group002"]
             }
             const expected: UserDetails = {
                 username: "user001",
                 firstName: "First",
                 prefix: "the",
                 lastName: "",
-                groups: [ "group001", "group002" ],
                 displayName: "First the ",
             }
 

--- a/src/test/typescript/mockserver/metadata.ts
+++ b/src/test/typescript/mockserver/metadata.ts
@@ -192,15 +192,11 @@ enum DateSchemeValues {
 
 interface AccessRight {
     category: AccessRightValues
-    group?: string
 }
 
 enum AccessRightValues {
     OPEN_ACCESS = "OPEN_ACCESS",
-    // OPEN_ACCESS_FOR_REGISTERED_USERS = "OPEN_ACCESS_FOR_REGISTERED_USERS",
-    GROUP_ACCESS = "GROUP_ACCESS",
     REQUEST_PERMISSION = "REQUEST_PERMISSION",
-    // NO_ACCESS = "NO_ACCESS",
 }
 
 enum TypesSchemeValues {
@@ -627,8 +623,7 @@ export const mandatoryOnly: Metadata = {
         },
     ],
     accessRights: {
-        category: AccessRightValues.GROUP_ACCESS,
-        group: "archaeology",
+        category: AccessRightValues.REQUEST_PERMISSION,
     },
     license: "http://creativecommons.org/publicdomain/zero/1.0",
     privacySensitiveDataPresent: PrivacySensitiveDataValues.YES,

--- a/src/test/typescript/mockserver/user.ts
+++ b/src/test/typescript/mockserver/user.ts
@@ -18,7 +18,6 @@ export interface User {
     firstName: string
     prefix?: string
     lastName: string
-    groups: string[]
 }
 
 export const User001: User = {
@@ -26,5 +25,4 @@ export const User001: User = {
     firstName: "First",
     prefix: undefined,
     lastName: "Namen",
-    groups: [ "group001", "group002"]
 }


### PR DESCRIPTION
Fixes EASY-

#### When applied it will
* the group-access option wil no longer be shown
* the group property is dropped from AccessRights objects
* the groups property is dropped from UserDetails objects

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
