### PR TITLE
posthumous review of #81

### DIFF
--- a/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
@@ -46,6 +46,4 @@ const AccessRightsField = ({ input }: FieldProps ) => {
     )
 }
 
-export default compose(
-    asField
-)(AccessRightsField)
+export default asField(AccessRightsField)


### PR DESCRIPTION
posthumous review of #81

Rationale: don't need `compose` anymore, since there is only 1 HOC to compose, whereas there were 2 before removing the code in #81.

@jo-pol @DANS-KNAW/easy for review