### PR TITLE
API expects SpatialBox and SpatialPoint as strings now

### DIFF
--- a/src/main/typescript/lib/metadata/SpatialBox.ts
+++ b/src/main/typescript/lib/metadata/SpatialBox.ts
@@ -54,8 +54,8 @@ export const boxConverter: (schemeValues: DropdownListEntry[]) => (b: any) => Bo
 
 export const boxDeconverter: (b: Box) => any = b => clean({
     scheme: b.scheme,
-    north: b.north && Number(b.north),
-    east: b.east && Number(b.east),
-    south: b.south && Number(b.south),
-    west: b.west && Number(b.west),
+    north: b.north,
+    east: b.east,
+    south: b.south,
+    west: b.west,
 })

--- a/src/main/typescript/lib/metadata/SpatialPoint.ts
+++ b/src/main/typescript/lib/metadata/SpatialPoint.ts
@@ -42,6 +42,6 @@ export const pointConverter: (schemeValues: DropdownListEntry[]) => (p: any) => 
 
 export const pointDeconverter: (p: Point) => any = p => clean({
     scheme: p.scheme,
-    x: p.x && Number(p.x),
-    y: p.y && Number(p.y),
+    x: p.x,
+    y: p.y,
 })

--- a/src/test/typescript/lib/metadata/SpatialBox.spec.ts
+++ b/src/test/typescript/lib/metadata/SpatialBox.spec.ts
@@ -118,10 +118,10 @@ describe("SpatialBox", () => {
             }
             const expected = {
                 scheme: "http://www.opengis.net/def/crs/EPSG/0/28992",
-                north: 1,
-                east: 2,
-                south: 3,
-                west: 4,
+                north: "1",
+                east: "2",
+                south: "3",
+                west: "4",
             }
             expect(boxDeconverter(input)).to.eql(expected)
         })

--- a/src/test/typescript/lib/metadata/SpatialPoint.spec.ts
+++ b/src/test/typescript/lib/metadata/SpatialPoint.spec.ts
@@ -104,8 +104,8 @@ describe("SpatialPoint", () => {
             }
             const expected = {
                 scheme: "http://www.opengis.net/def/crs/EPSG/0/28992",
-                x: 1,
-                y: 2,
+                x: "1",
+                y: "2",
             }
             expect(pointDeconverter(input)).to.eql(expected)
         })


### PR DESCRIPTION
Accompanies https://github.com/DANS-KNAW/easy-deposit-api/pull/69

Makes sure that easy-deposit-ui sends strings for the `SpatialBox` and `SpatialPoint`.

@DANS-KNAW/easy for review