### PR TITLE
Fix table background

### DIFF
--- a/src/main/typescript/components/overview/DepositTableHead.tsx
+++ b/src/main/typescript/components/overview/DepositTableHead.tsx
@@ -17,7 +17,7 @@ import * as React from "react"
 
 const DepositTableHead = () => (
     <thead>
-    <tr className="row text-light">
+    <tr className="row text-light ml-0 mr-0">
         {/* these column sizes need to match with the sizes in DepositTableRow */}
         <th className="col-10 col-sm-11 col-md-3" scope="col">Dataset</th>
         <th className="col-12 col-sm-12 col-md-2" scope="col">Date</th>

--- a/src/main/typescript/components/overview/DepositTableHead.tsx
+++ b/src/main/typescript/components/overview/DepositTableHead.tsx
@@ -17,7 +17,7 @@ import * as React from "react"
 
 const DepositTableHead = () => (
     <thead>
-    <tr className="row bg-primary text-light">
+    <tr className="row text-light">
         {/* these column sizes need to match with the sizes in DepositTableRow */}
         <th className="col-10 col-sm-11 col-md-3" scope="col">Dataset</th>
         <th className="col-12 col-sm-12 col-md-2" scope="col">Date</th>

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -49,7 +49,7 @@ const DepositTableRow = ({ deposit, deleting, deleteDeposit, editable, enterDepo
         </button>
 
     return (
-        <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ")}
+        <tr className={["row", editable ? "editable_table_row" : "not_editable_table_row"].join(" ") + " ml-0 mr-0"}
             onClick={enterDeposit}>
             {/* these column sizes need to match with the sizes in DepositTableHead */}
             <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row">{title}</td>


### PR DESCRIPTION
The deposit overview table had a small red line on the right side of the table head. This was due to the background being set to `.bg-primary`, which is `color:red` in our definitions (_whether it is correct to make `.bg-primary` as `color:red` is a question for another day! I think that should be something like `.bg-danger`._). However, since the table head is overlayed with a gradient, we don't need the red background anymore.

Besides, the table has negative margins by default (thanks, Bootstrap!), so it looked somewhat odd on smaller screens, in comparison to the deposit form. Therefore I added to both the table head and table rows a `ml-0 and mr-0`, as it is supposed to be.

@DANS-KNAW/easy for review