### PR TITLE
NO JIRA ISSUE: dropped prefix from doi values in test data

### DIFF
--- a/src/test/typescript/lib/metadata/Identifier.spec.ts
+++ b/src/test/typescript/lib/metadata/Identifier.spec.ts
@@ -46,11 +46,11 @@ describe("Identifier", () => {
             const input = [
                 {
                     scheme: "id-type:DOI",
-                    value: "doi:10.17632/DANS.6wg5xccnjd.1",
+                    value: "10.17632/DANS.6wg5xccnjd.1",
                 },
             ]
             const expected = {
-                "id-type:DOI": "doi:10.17632/DANS.6wg5xccnjd.1",
+                "id-type:DOI": "10.17632/DANS.6wg5xccnjd.1",
             }
             expect(identifiersConverter(input)).to.eql(expected)
         })
@@ -71,9 +71,9 @@ describe("Identifier", () => {
 
         it("should extract the DOI from the input object", () => {
             const input = {
-                "id-type:DOI": "doi:10.17632/DANS.6wg5xccnjd.1",
+                "id-type:DOI": "10.17632/DANS.6wg5xccnjd.1",
             }
-            const expected = "doi:10.17632/DANS.6wg5xccnjd.1"
+            const expected = "10.17632/DANS.6wg5xccnjd.1"
             expect(doiConverter(input)).to.eql(expected)
         })
     })
@@ -81,10 +81,10 @@ describe("Identifier", () => {
     describe("doiDeconverter", () => {
 
         it("should convert a DOI into the correct external model", () => {
-            const input = "doi:10.17632/DANS.6wg5xccnjd.1"
+            const input = "10.17632/DANS.6wg5xccnjd.1"
             const expected = {
                 scheme: "id-type:DOI",
-                value: "doi:10.17632/DANS.6wg5xccnjd.1",
+                value: "10.17632/DANS.6wg5xccnjd.1",
             }
             expect(doiDeconverter(input)).to.eql(expected)
         })

--- a/src/test/typescript/mockserver/db.ts
+++ b/src/test/typescript/mockserver/db.ts
@@ -168,7 +168,7 @@ export const getDoi: (id: DepositId) => Doi | undefined = id => {
         return undefined
 }
 
-const generateNewDoi = () => `doi:10.17632/DANS.${uuid().substr(0, 10)}.1`
+const generateNewDoi = () => `10.17632/DANS.${uuid().substr(0, 10)}.1`
 
 export const getUser: () => User = () => {
     return User001

--- a/src/test/typescript/mockserver/metadata.ts
+++ b/src/test/typescript/mockserver/metadata.ts
@@ -244,7 +244,7 @@ export const allfields: Metadata = {
     identifiers: [
         {
             scheme: DansIdentifierSchemeValues.DOI,
-            value: "doi:10.17632/DANS.6wg5xccnjd.1",
+            value: "10.17632/DANS.6wg5xccnjd.1",
         },
     ],
     languageOfDescription: {
@@ -577,7 +577,7 @@ export const mandatoryOnly: Metadata = {
     identifiers: [
         {
             scheme: DansIdentifierSchemeValues.DOI,
-            value: "doi:10.17632/DANS.6wg5xccnjd.2",
+            value: "10.17632/DANS.6wg5xccnjd.2",
         },
     ],
     languageOfDescription: {


### PR DESCRIPTION
Fixes EASY-

#### When applied it will
* drop the prefix "doi:" from doi values,
  problem was detected with https://github.com/DANS-KNAW/easy-deposit-api/pull/78#pullrequestreview-176660917
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
