### PR TITLE
EASY-1767: merging Creator/Contributor fields

### DIFF
--- a/src/main/resources/constants/contributorRoles.json
+++ b/src/main/resources/constants/contributorRoles.json
@@ -1,4 +1,12 @@
 {
+  "Creator": {
+    "title": "Creator",
+    "viewName": "Creator"
+  },
+  "": {
+    "title": "",
+    "viewName": "No role"
+  },
   "DataCollector": {
     "title": "Data collector",
     "viewName": "Data collector"

--- a/src/main/resources/css/form.css
+++ b/src/main/resources/css/form.css
@@ -114,6 +114,13 @@
     border-color: var(--form-field-border)!important;
 }
 
+.input-element .contributor.is-invalid {
+    border-color: var(--dans-red)!important;
+}
+.input-element .contributor.is-invalid ~ .invalid-feedback {
+    display: block;
+}
+
 .input-element .contributor:last-child,
 .input-element .contributor > .form-row:last-child > .form-group {
     margin-bottom: 0!important;

--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -45,6 +45,7 @@ import { depositFormName } from "../../constants/depositFormConstants"
 import { fetchAllDropdownsAndMetadata } from "../../actions/dropdownActions"
 import { Files, LoadingState as FileOverviewLoadingState } from "../../model/FileInfo"
 import { fetchFiles } from "../../actions/fileOverviewActions"
+import { formValidate } from "./Validation"
 
 interface FetchMetadataErrorProps {
     fetchError?: string
@@ -252,7 +253,11 @@ const composedHOC = compose(
             saveDraft,
             submitDeposit,
         }),
-    reduxForm({ form: depositFormName, enableReinitialize: true }),
+    reduxForm({
+        form: depositFormName,
+        enableReinitialize: true,
+        validate: formValidate
+    }),
 )
 
 export default composedHOC(DepositForm)

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -126,7 +126,6 @@ export const validateContributors: (contributors: Contributor[]) => Contributor[
     })
 }
 
-// TODO test
 export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFormMetadata> = values => {
     const errors: any = {}
 

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -36,13 +36,14 @@ export const mandatoryRadioButtonValidator = (value: any, name: string) => {
         : undefined
 }
 
-export const mandatoryPrivacySensitiveDataValidator: Validator = (value, allValues, props, name) => {
+export const mandatoryPrivacySensitiveDataValidator = (value: any) => {
+    const errMsg = "please determine whether privacy sensitive data is present in this deposit"
     if (!value)
-        return `no ${name} was provided`
+        return errMsg
     else if (typeof value === "string" && (value.trim() === "" || value.trim() === PrivacySensitiveDataValue.UNSPECIFIED))
-        return `no ${name} was provided`
+        return errMsg
     else if (typeof value === "object" && Object.keys(value).filter(key => value[key] && value[key].trim() !== "").length === 0)
-        return `no ${name} was provided`
+        return errMsg
     else
         return undefined
 }
@@ -150,6 +151,9 @@ export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFo
     errors.accessRights = mandatoryRadioButtonValidator(values.accessRights, "access right")
     errors.license = mandatoryRadioButtonValidator(values.license, "license")
     errors.dateAvailable = dateAvailableMustBeAfterDateCreated(values.dateCreated, values.dateAvailable)
+
+    // privacy sensitive data form
+    errors.privacySensitiveDataPresent = mandatoryPrivacySensitiveDataValidator(values.privacySensitiveDataPresent)
 
     console.log("errors", errors)
 

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -30,9 +30,9 @@ export const mandatoryFieldArrayValidator = (values: any[] | undefined, name: st
         : undefined
 }
 
-export const mandatoryRadioButtonValidator: Validator = (value, allValues, props, name) => {
+export const mandatoryRadioButtonValidator = (value: any, name: string) => {
     return !value || typeof value === "object" && Object.keys(value).filter(key => value[key] && value[key].trim() !== "").length === 0
-        ? `no ${name} was provided`
+        ? `no ${name} was chosen`
         : undefined
 }
 
@@ -53,7 +53,7 @@ export const checkboxMustBeChecked: Validator = (value?: any) => {
         : undefined
 }
 
-export const dateAvailableMustBeAfterDateCreated: Validator = (value, { dateCreated, dateAvailable }: DepositFormMetadata) => {
+export const dateAvailableMustBeAfterDateCreated = (dateCreated?: Date, dateAvailable?: Date) => {
     return dateCreated && dateAvailable && dateAvailable < dateCreated
         ? "'Date available' cannot be a date earlier than 'Date created'"
         : undefined
@@ -127,14 +127,11 @@ const validateContributors: (contributors: Contributor[]) => Contributor[] = con
 export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFormMetadata> = values => {
     const errors: any = {}
 
-    errors.doi = { _error: mandatoryFieldValidator(values.doi, "doi") }
-
-    errors.languageOfDescription = { _error: mandatoryFieldValidator(values.languageOfDescription, "language of description") }
-
+    // basic information form
+    errors.doi = mandatoryFieldValidator(values.doi, "doi")
+    errors.languageOfDescription = mandatoryFieldValidator(values.languageOfDescription, "language of description")
     errors.titles = { _error: mandatoryFieldArrayValidator(values.titles, "titles") }
-
-    errors.description = { _error: mandatoryFieldValidator(values.description, "description") }
-
+    errors.description = mandatoryFieldValidator(values.description, "description")
     if (values.contributors) {
         const oneContributor = atLeastOneContributor(values.contributors)
         const oneCreator = atLeastOneCreator(values.contributors)
@@ -146,10 +143,13 @@ export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFo
         else
             errors.contributors = validateContributors(values.contributors)
     }
-
-    errors.dateCreated = { _error: mandatoryFieldValidator(values.dateCreated, "date created") }
-
+    errors.dateCreated = mandatoryFieldValidator(values.dateCreated, "date created")
     errors.audiences = { _error: mandatoryFieldArrayValidator(values.audiences, "audiences") }
+
+    // license and access form
+    errors.accessRights = mandatoryRadioButtonValidator(values.accessRights, "access right")
+    errors.license = mandatoryRadioButtonValidator(values.license, "license")
+    errors.dateAvailable = dateAvailableMustBeAfterDateCreated(values.dateCreated, values.dateAvailable)
 
     console.log("errors", errors)
 

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -18,13 +18,13 @@ import { PrivacySensitiveDataValue } from "../../lib/metadata/PrivacySensitiveDa
 import { DepositFormMetadata } from "./parts"
 import { Contributor, creatorRole } from "../../lib/metadata/Contributor"
 
-export const mandatoryFieldValidator: Validator = (value, allValues, props, name) => {
+export const mandatoryFieldValidator = (value: any, name: string) => {
     return !value || typeof value == "string" && value.trim() === ""
         ? `no ${name} was provided`
         : undefined
 }
 
-export const mandatoryFieldArrayValidator: Validator = (values: any[], allValues, props, name) => {
+export const mandatoryFieldArrayValidator = (values: any[] | undefined, name: string) => {
     return !values || (values && (values.length == 0 || values.filter(value => value && value.trim() !== "").length === 0))
         ? `no ${name} were provided`
         : undefined
@@ -127,6 +127,14 @@ const validateContributors: (contributors: Contributor[]) => Contributor[] = con
 export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFormMetadata> = values => {
     const errors: any = {}
 
+    errors.doi = { _error: mandatoryFieldValidator(values.doi, "doi") }
+
+    errors.languageOfDescription = { _error: mandatoryFieldValidator(values.languageOfDescription, "language of description") }
+
+    errors.titles = { _error: mandatoryFieldArrayValidator(values.titles, "titles") }
+
+    errors.description = { _error: mandatoryFieldValidator(values.description, "description") }
+
     if (values.contributors) {
         const oneContributor = atLeastOneContributor(values.contributors)
         const oneCreator = atLeastOneCreator(values.contributors)
@@ -138,6 +146,12 @@ export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFo
         else
             errors.contributors = validateContributors(values.contributors)
     }
+
+    errors.dateCreated = { _error: mandatoryFieldValidator(values.dateCreated, "date created") }
+
+    errors.audiences = { _error: mandatoryFieldArrayValidator(values.audiences, "audiences") }
+
+    console.log("errors", errors)
 
     return errors
 }

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -16,7 +16,7 @@
 import { FormErrors, Validator } from "redux-form"
 import { PrivacySensitiveDataValue } from "../../lib/metadata/PrivacySensitiveData"
 import { DepositFormMetadata } from "./parts"
-import { Contributor } from "../../lib/metadata/Contributor"
+import { Contributor, creatorRole } from "../../lib/metadata/Contributor"
 
 export const mandatoryFieldValidator: Validator = (value, allValues, props, name) => {
     return !value || typeof value == "string" && value.trim() === ""
@@ -89,6 +89,18 @@ export const atLeastOneContributor: Validator = (contributors: Contributor[]) =>
         return undefined
 }
 
+// TODO test
+const atLeastOneCreator: Validator = (contributors: Contributor[]) => {
+    const containsCreator = contributors.map(contributor => contributor.role === creatorRole)
+        .reduce((prev, curr) => prev || curr, false)
+
+    if (!containsCreator)
+        return "at least one creator is required"
+    else
+        return undefined
+}
+
+// TODO test
 const validateContributors: (contributors: Contributor[]) => Contributor[] = contributors => {
     // validate that mandatory fields are filled in for each contributor
     return contributors.map((contributor: Contributor) => {
@@ -111,13 +123,20 @@ const validateContributors: (contributors: Contributor[]) => Contributor[] = con
     })
 }
 
+// TODO test
 export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFormMetadata> = values => {
     const errors: any = {}
 
     if (values.contributors) {
         const oneContributor = atLeastOneContributor(values.contributors)
-        // TODO validate that at least one creator is given
-        errors.contributors = oneContributor ? { _error: oneContributor } : validateContributors(values.contributors)
+        const oneCreator = atLeastOneCreator(values.contributors)
+
+        if (oneContributor)
+            errors.contributors = { _error: oneContributor }
+        else if (oneCreator)
+            errors.contributors = { _error: oneCreator }
+        else
+            errors.contributors = validateContributors(values.contributors)
     }
 
     return errors

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FormErrors, Validator } from "redux-form"
+import { FormErrors } from "redux-form"
 import { PrivacySensitiveDataValue } from "../../lib/metadata/PrivacySensitiveData"
 import { DepositFormMetadata } from "./parts"
 import { Contributor, creatorRole } from "../../lib/metadata/Contributor"
@@ -60,43 +60,48 @@ export const dateAvailableMustBeAfterDateCreated = (dateCreated?: Date, dateAvai
 
 const checkNonEmpty: (s: string | undefined) => boolean = s => s ? s.trim() !== "" : false
 
-export const atLeastOneContributor: Validator = (contributors: Contributor[]) => {
-    const nonEmptyContributors = () => contributors.map(contributor => {
-        const nonEmptyOrganization = checkNonEmpty(contributor.organization)
-        const nonEmptyTitles = checkNonEmpty(contributor.titles)
-        const nonEmptyInitials = checkNonEmpty(contributor.initials)
-        const nonEmptyInsertions = checkNonEmpty(contributor.insertions)
-        const nonEmptySurname = checkNonEmpty(contributor.surname)
-        const nonEmptyIdentifiers = contributor.ids
-            ? contributor.ids.map(id => {
-                const nonEmptyIdScheme = checkNonEmpty(id.scheme)
-                const nonEmptyIdValue = checkNonEmpty(id.value)
-
-                return nonEmptyIdScheme || nonEmptyIdValue
-            }).reduce((prev, curr) => prev || curr, false)
-            : false
-        // note that 'role' is not part of this validation, as it defaults to 'Creator'
-
-        return nonEmptyOrganization || nonEmptyTitles || nonEmptyInitials || nonEmptyInsertions || nonEmptySurname || nonEmptyIdentifiers
-    }).reduce((prev, curr) => prev || curr, false)
-
+export const atLeastOneContributor = (contributors?: Contributor[]) => {
     if (!contributors)
         return "no contributors were provided"
-    else if (!nonEmptyContributors())
-        return "no contributors were provided"
-    else
-        return undefined
+    else {
+        const nonEmptyContributors = contributors.map(contributor => {
+            const nonEmptyOrganization = checkNonEmpty(contributor.organization)
+            const nonEmptyTitles = checkNonEmpty(contributor.titles)
+            const nonEmptyInitials = checkNonEmpty(contributor.initials)
+            const nonEmptyInsertions = checkNonEmpty(contributor.insertions)
+            const nonEmptySurname = checkNonEmpty(contributor.surname)
+            const nonEmptyIdentifiers = contributor.ids
+                ? contributor.ids.map(id => {
+                    const nonEmptyIdScheme = checkNonEmpty(id.scheme)
+                    const nonEmptyIdValue = checkNonEmpty(id.value)
+
+                    return nonEmptyIdScheme || nonEmptyIdValue
+                }).reduce((prev, curr) => prev || curr, false)
+                : false
+            // note that 'role' is not part of this validation, as it defaults to 'Creator'
+
+            return nonEmptyOrganization || nonEmptyTitles || nonEmptyInitials || nonEmptyInsertions || nonEmptySurname || nonEmptyIdentifiers
+        }).reduce((prev, curr) => prev || curr, false)
+
+        if (!nonEmptyContributors)
+            return "no contributors were provided"
+        else
+            return undefined
+    }
 }
 
-// TODO test
-const atLeastOneCreator: Validator = (contributors: Contributor[]) => {
-    const containsCreator = contributors.map(contributor => contributor.role === creatorRole)
-        .reduce((prev, curr) => prev || curr, false)
-
-    if (!containsCreator)
+export const atLeastOneCreator = (contributors?: Contributor[]) => {
+    if (!contributors)
         return "at least one creator is required"
-    else
-        return undefined
+    else {
+        const containsCreator = contributors.map(contributor => contributor.role === creatorRole)
+            .reduce((prev, curr) => prev || curr, false)
+
+        if (!containsCreator)
+            return "at least one creator is required"
+        else
+            return undefined
+    }
 }
 
 // TODO test

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -48,10 +48,8 @@ export const mandatoryPrivacySensitiveDataValidator = (value: any) => {
         return undefined
 }
 
-export const checkboxMustBeChecked: Validator = (value?: any) => {
-    return !value || value !== true
-        ? "Accept the license agreement before submitting this dataset"
-        : undefined
+export const checkboxMustBeChecked = (value: boolean | undefined, msg: string) => {
+    return !value ? msg : undefined
 }
 
 export const dateAvailableMustBeAfterDateCreated = (dateCreated?: Date, dateAvailable?: Date) => {
@@ -154,6 +152,9 @@ export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFo
 
     // privacy sensitive data form
     errors.privacySensitiveDataPresent = mandatoryPrivacySensitiveDataValidator(values.privacySensitiveDataPresent)
+
+    // accept license agreement
+    errors.acceptLicenseAgreement = checkboxMustBeChecked(values.acceptLicenseAgreement, "Accept the license agreement before submitting this dataset")
 
     console.log("errors", errors)
 

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -104,8 +104,7 @@ export const atLeastOneCreator = (contributors?: Contributor[]) => {
     }
 }
 
-// TODO test
-const validateContributors: (contributors: Contributor[]) => Contributor[] = contributors => {
+export const validateContributors: (contributors: Contributor[]) => Contributor[] = contributors => {
     // validate that mandatory fields are filled in for each contributor
     return contributors.map((contributor: Contributor) => {
         const nonEmptyOrganization = checkNonEmpty(contributor.organization)

--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -45,7 +45,6 @@ import * as moment from "moment"
 import IsoDateFieldArray from "./basicInformation/IsoDateFieldArray"
 import RelationFieldArray from "./basicInformation/RelationFieldArray"
 import RelatedIdentifierFieldArray from "./basicInformation/RelatedIdentifierFieldArray"
-import { atLeastOneContributor, mandatoryFieldArrayValidator, mandatoryFieldValidator } from "../Validation"
 
 export interface BasicInformationFormData {
     doi?: Doi
@@ -87,7 +86,6 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                mandatory
                helpText
                depositId={depositId}
-               validate={[mandatoryFieldValidator]}
                component={DoiField}/>
 
         <Field name="languageOfDescription"
@@ -96,7 +94,6 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                helpText
                withEmptyDefault
                dropdown={languages}
-               validate={[mandatoryFieldValidator]}
                component={LanguageField}/>
 
         <RepeatableField name="titles"
@@ -105,7 +102,6 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                          helpText
                          empty={emptyString}
                          fieldNames={[(name: string) => name]}
-                         validate={[mandatoryFieldArrayValidator]}
                          component={TextFieldArray}/>
 
         <RepeatableField name="alternativeTitles"
@@ -121,7 +117,6 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                mandatory
                rows={5}
                maxRows={15}
-               validate={[mandatoryFieldValidator]}
                component={TextArea}/>
 
         <RepeatableFieldWithDropdown name="contributors"
@@ -150,7 +145,6 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                yearDropdownItemNumber={10}
                scrollableYearDropdown
                maxDate={moment()}
-               validate={[mandatoryFieldValidator]}
                component={DatePickerField}/>
 
         <RepeatableFieldWithDropdown name="audiences"
@@ -160,7 +154,6 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                                      empty={emptyString}
                                      fieldNames={[(name: string) => name]}
                                      dropdowns={{ audiences: audiences }}
-                                     validate={[mandatoryFieldArrayValidator]}
                                      component={AudienceFieldArray}/>
 
         <RepeatableField name="subjects"

--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -27,7 +27,7 @@ import {
     QualifiedSchemedValue,
     SchemedValue,
 } from "../../../lib/metadata/Value"
-import { Contributor } from "../../../lib/metadata/Contributor"
+import { Contributor, emptyContributor } from "../../../lib/metadata/Contributor"
 import { emptyQualifiedDate, emptyQualifiedStringDate, QualifiedDate } from "../../../lib/metadata/Date"
 import { emptyRelation, Relation } from "../../../lib/metadata/Relation"
 import { emptyString } from "../../../lib/metadata/misc"
@@ -128,6 +128,7 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                                      label="People & organisations"
                                      helpText
                                      mandatory
+                                     empty={emptyContributor}
                                      fieldNames={[
                                          (name: string) => `${name}.titles`, // 0
                                          (name: string) => `${name}.initials`, // 1

--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -27,7 +27,7 @@ import {
     QualifiedSchemedValue,
     SchemedValue,
 } from "../../../lib/metadata/Value"
-import { Contributor, emptyContributor } from "../../../lib/metadata/Contributor"
+import { Contributor } from "../../../lib/metadata/Contributor"
 import { emptyQualifiedDate, emptyQualifiedStringDate, QualifiedDate } from "../../../lib/metadata/Date"
 import { emptyRelation, Relation } from "../../../lib/metadata/Relation"
 import { emptyString } from "../../../lib/metadata/misc"
@@ -53,7 +53,6 @@ export interface BasicInformationFormData {
     titles?: string[]
     alternativeTitles?: string[]
     description?: string
-    creators?: Contributor[]
     contributors?: Contributor[]
     dateCreated?: Date
     audiences?: string[]
@@ -125,30 +124,10 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                validate={[mandatoryFieldValidator]}
                component={TextArea}/>
 
-        <RepeatableFieldWithDropdown name="creators"
-                                     label="Creator"
+        <RepeatableFieldWithDropdown name="contributors"
+                                     label="People & organisations"
                                      helpText
                                      mandatory
-                                     empty={emptyContributor}
-                                     fieldNames={[
-                                         (name: string) => `${name}.titles`, // 0
-                                         (name: string) => `${name}.initials`, // 1
-                                         (name: string) => `${name}.insertions`, // 2
-                                         (name: string) => `${name}.surname`, // 3
-                                         (name: string) => `${name}.ids`, // 4
-                                         (name: string) => `${name}.role`, // 5
-                                         (name: string) => `${name}.organization`, // 6
-                                     ]}
-                                     dropdowns={{
-                                         ids: contributorIds,
-                                         roles: contributorRoles,
-                                     }}
-                                     component={ContributorFields}/>
-
-        <RepeatableFieldWithDropdown name="contributors"
-                                     label="Contributors"
-                                     helpText
-                                     empty={emptyContributor}
                                      fieldNames={[
                                          (name: string) => `${name}.titles`, // 0
                                          (name: string) => `${name}.initials`, // 1

--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -45,7 +45,7 @@ import * as moment from "moment"
 import IsoDateFieldArray from "./basicInformation/IsoDateFieldArray"
 import RelationFieldArray from "./basicInformation/RelationFieldArray"
 import RelatedIdentifierFieldArray from "./basicInformation/RelatedIdentifierFieldArray"
-import { mandatoryFieldArrayValidator, mandatoryFieldValidator } from "../Validation"
+import { atLeastOneContributor, mandatoryFieldArrayValidator, mandatoryFieldValidator } from "../Validation"
 
 export interface BasicInformationFormData {
     doi?: Doi
@@ -138,6 +138,7 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                                          (name: string) => `${name}.organization`, // 6
                                      ]}
                                      dropdowns={{ ids: contributorIds, roles: contributorRoles }}
+                                     validate={[atLeastOneContributor]}
                                      component={ContributorFields}/>
 
         <Field name="dateCreated"

--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -139,7 +139,6 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                                          (name: string) => `${name}.organization`, // 6
                                      ]}
                                      dropdowns={{ ids: contributorIds, roles: contributorRoles }}
-                                     validate={[atLeastOneContributor]}
                                      component={ContributorFields}/>
 
         <Field name="dateCreated"

--- a/src/main/typescript/components/form/parts/DepositLicenseForm.tsx
+++ b/src/main/typescript/components/form/parts/DepositLicenseForm.tsx
@@ -67,7 +67,6 @@ const DepositLicenseForm = () => (
 
         <div className="row form-group input-element">
             <Field name="acceptLicenseAgreement"
-                   validate={[checkboxMustBeChecked]}
                    component={Checkbox}>
                 Yes, I accept and understand the terms of the License agreement<Mandatory/>
             </Field>

--- a/src/main/typescript/components/form/parts/LicenseAndAccessForm.tsx
+++ b/src/main/typescript/components/form/parts/LicenseAndAccessForm.tsx
@@ -72,7 +72,6 @@ const LicenseAndAccessForm = ({ licenses, contributorIds }: LicenseAndAccessForm
                label="Access rights"
                mandatory
                helpText
-               validate={[mandatoryRadioButtonValidator]}
                component={AccessRightsField}/>
 
         <Field name="license"
@@ -81,7 +80,6 @@ const LicenseAndAccessForm = ({ licenses, contributorIds }: LicenseAndAccessForm
                helpText
                withEmptyDefault
                dropdown={licenses}
-               validate={[mandatoryRadioButtonValidator]}
                component={LicenseField}/>
 
         <Field name="dateAvailable"
@@ -90,7 +88,6 @@ const LicenseAndAccessForm = ({ licenses, contributorIds }: LicenseAndAccessForm
                todayButton="Today"
                minDate={moment()}
                maxDate={moment().add(2, "years")}
-               validate={[dateAvailableMustBeAfterDateCreated]}
                component={DatePickerField}/>
     </>
 )

--- a/src/main/typescript/components/form/parts/PrivacySensitiveDataForm.tsx
+++ b/src/main/typescript/components/form/parts/PrivacySensitiveDataForm.tsx
@@ -59,7 +59,6 @@ const PrivacySensitiveDataForm = () => (
                        value: "NO, this dataset does not contain personal data",
                    },
                ]}
-               validate={[mandatoryPrivacySensitiveDataValidator]}
                component={PrivacySensitiveRadioChoices}/>
     </>
 )

--- a/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
@@ -84,12 +84,12 @@ const ContributorField = ({ names, idValues, roleValues, className }: Contributo
             </div>
             {/* TODO these fields need to be added later. they do not yet occur in the UI model, nor in the API */}
             {/*<div className="col form-group col-md-3 mb-1">
-            <label>Identifier</label>
-            <Field name={""}
-                   choices={idValues}
-                   withEmptyDefault
-                   emptyDefault="Choose..."
-                   component={DropdownFieldInput}/>
+                <label>Identifier</label>
+                <Field name={""}
+                       choices={idValues}
+                       withEmptyDefault
+                       emptyDefault="Choose..."
+                       component={DropdownFieldInput}/>
             </div>
             <div className="col form-group col-md-3 mb-1">
                 <label/>

--- a/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
@@ -16,7 +16,7 @@
 import * as React from "react"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
 import { Field } from "redux-form"
-import TextField from "./TextField"
+import TextField, { TextFieldProps } from "./TextField"
 import { DropdownFieldInput } from "./DropDownField"
 import { DropdownListEntry } from "../../model/DropdownLists"
 import RemoveButton from "./RemoveButton"
@@ -80,7 +80,7 @@ const ContributorField = ({ names, idValues, roleValues, className }: Contributo
                 <label>Organization</label>
                 <Field name={names[6]}
                        placeholder="organization"
-                       component={TextField}/>
+                       component={TextFieldWrapper}/>
             </div>
             {/* TODO these fields need to be added later. they do not yet occur in the UI model, nor in the API */}
             {/*<div className="col form-group col-md-3 mb-1">
@@ -110,7 +110,7 @@ const ContributorField = ({ names, idValues, roleValues, className }: Contributo
                 <label>Initials<Mandatory/></label>
                 <Field name={names[1]}
                        placeholder="initials"
-                       component={TextField}/>
+                       component={TextFieldWrapper}/>
             </div>
             <div className="col form-group col-md-3 mb-1">
                 <label>Prefix</label>
@@ -122,7 +122,7 @@ const ContributorField = ({ names, idValues, roleValues, className }: Contributo
                 <label>Surname<Mandatory/></label>
                 <Field name={names[3]}
                        placeholder="surname"
-                       component={TextField}/>
+                       component={TextFieldWrapper}/>
             </div>
         </div>
 
@@ -137,5 +137,19 @@ const ContributorField = ({ names, idValues, roleValues, className }: Contributo
                                      component={ContributorIdArray}/>
     </div>
 )
+
+const TextFieldWrapper = (props: TextFieldProps) => {
+    const { meta } = props
+
+    const changed = (meta as any).changed
+    const hasError = meta.error && (changed || meta.submitFailed)
+
+    return (
+        <>
+            <TextField {...props} className={hasError ? "is-invalid" : ""}/>
+            {hasError && <span className="invalid-feedback">{meta.error}</span>}
+        </>
+    )
+}
 
 export default asFieldArray(ContributorField)

--- a/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
@@ -20,29 +20,36 @@ import TextField from "./TextField"
 import { DropdownFieldInput } from "./DropDownField"
 import { DropdownListEntry } from "../../model/DropdownLists"
 import RemoveButton from "./RemoveButton"
-import { FieldArrayPropsWithDropdown, RepeatableFieldWithDropdown } from "./ReduxFormUtils"
+import { FieldArrayProps, FieldArrayPropsWithDropdown, RepeatableFieldWithDropdown } from "./ReduxFormUtils"
 import { emptySchemedValue, SchemedValue } from "../metadata/Value"
 import AddButton from "./AddButton"
 import Mandatory from "./Mandatory"
+import { Contributor } from "../metadata/Contributor"
 
 const ContributorIdArray = ({ fields, fieldNames, empty, dropdowns: { contributorIds } }: FieldArrayPropsWithDropdown<SchemedValue, DropdownListEntry[]>) => (
     <>
+        <div className="form-row">
+            <div className="col form-group col-12 col-md-3 pl-0 mb-0">
+                <label>Identifier</label>
+            </div>
+        </div>
+
         {fields.map((name, index) => (
             <div className="form-row mb-2" key={`${name}.${index}`}>
-                <div className="col-12 col-md-3 pl-0">
+                <div className="col col-12 col-md-3 pl-0">
                     <Field name={fieldNames[0](name)}
                            choices={contributorIds}
                            withEmptyDefault
                            component={DropdownFieldInput}/>
                 </div>
 
-                <div className="col-12 col-md-6 pr-2">
+                <div className="col col-12 col-md-6">
                     <Field name={fieldNames[1](name)}
                            placeholder="ID"
                            component={TextField}/>
                 </div>
 
-                <div className="col-2 pl-0 pr-0 remove-and-add-buttons">
+                <div className="col col-2 remove-and-add-buttons">
                     <RemoveButton onClick={() => fields.remove(index)}
                                   className="mr-2"
                                   disabled={fields.length <= 1}/>
@@ -53,65 +60,71 @@ const ContributorIdArray = ({ fields, fieldNames, empty, dropdowns: { contributo
     </>
 )
 
-interface NameProps {
-    titleName: string
-    initialsName: string
-    insertionsName: string
-    surnameName: string
-}
-
-const Name = ({ titleName, initialsName, insertionsName, surnameName }: NameProps) => (
-    <>
-        <div className="col form-group col-md-3 mb-2">
-            <label>Titles</label>
-            <Field name={titleName}
-                   placeholder="(acadamic) title(s)"
-                   component={TextField}/>
-        </div>
-        <div className="col form-group col-md-3 mb-2">
-            <label>Initials<Mandatory/></label>
-            <Field name={initialsName}
-                   placeholder="initials"
-                   component={TextField}/>
-        </div>
-        <div className="col form-group col-md-3 mb-2">
-            <label>Prefix</label>
-            <Field name={insertionsName}
-                   placeholder="prefix"
-                   component={TextField}/>
-        </div>
-        <div className="col form-group col-md-3 mb-2">
-            <label>Surname<Mandatory/></label>
-            <Field name={surnameName}
-                   placeholder="surname"
-                   component={TextField}/>
-        </div>
-    </>
-)
-
-interface ContributorFieldProps extends InnerComponentProps {
+interface ContributorFieldProps extends InnerComponentProps, FieldArrayProps<Contributor> {
     idValues: DropdownListEntry[]
     roleValues?: DropdownListEntry[]
 }
 
-const ContributorField = ({ names, idValues, roleValues }: ContributorFieldProps) => (
-    <div className="border rounded contributor p-2 mb-4">
-        <div className="form-row">
-            <Name titleName={names[0]}
-                  initialsName={names[1]}
-                  insertionsName={names[2]}
-                  surnameName={names[3]}/>
-        </div>
-
+const ContributorField = ({ names, idValues, roleValues, className }: ContributorFieldProps) => (
+    <div className={`border rounded contributor pt-2 pl-2 pr-2 pb-0 ${className || ""}`}>
         {roleValues && <div className="form-row">
-            <div className="col mb-2">
+            <div className="col form-group col-md-6 mb-1">
                 <Field name={names[5]}
                        choices={roleValues || []}
-                       withEmptyDefault
-                       emptyDefault="Choose role..."
                        component={DropdownFieldInput}/>
             </div>
         </div>}
+
+        <div className="form-row">
+            <div className="col form-group col-md-6 mb-1">
+                <label>Organization</label>
+                <Field name={names[6]}
+                       placeholder="organization"
+                       component={TextField}/>
+            </div>
+            {/* TODO these fields need to be added later. they do not yet occur in the UI model, nor in the API */}
+            {/*<div className="col form-group col-md-3 mb-1">
+            <label>Identifier</label>
+            <Field name={""}
+                   choices={idValues}
+                   withEmptyDefault
+                   emptyDefault="Choose..."
+                   component={DropdownFieldInput}/>
+            </div>
+            <div className="col form-group col-md-3 mb-1">
+                <label/>
+                <Field name={"abc"}
+                       placeholder="identifier"
+                       component={TextField}/>
+            </div>*/}
+        </div>
+
+        <div className="form-row">
+            <div className="col form-group col-md-3 mb-1">
+                <label>Titles</label>
+                <Field name={names[0]}
+                       placeholder="(acadamic) title(s)"
+                       component={TextField}/>
+            </div>
+            <div className="col form-group col-md-3 mb-1">
+                <label>Initials<Mandatory/></label>
+                <Field name={names[1]}
+                       placeholder="initials"
+                       component={TextField}/>
+            </div>
+            <div className="col form-group col-md-3 mb-1">
+                <label>Prefix</label>
+                <Field name={names[2]}
+                       placeholder="prefix"
+                       component={TextField}/>
+            </div>
+            <div className="col form-group col-md-3 mb-1">
+                <label>Surname<Mandatory/></label>
+                <Field name={names[3]}
+                       placeholder="surname"
+                       component={TextField}/>
+            </div>
+        </div>
 
         <RepeatableFieldWithDropdown name={names[4]}
                                      label="Contributor Ids"
@@ -122,15 +135,6 @@ const ContributorField = ({ names, idValues, roleValues }: ContributorFieldProps
                                      ]}
                                      dropdowns={{ contributorIds: idValues }}
                                      component={ContributorIdArray}/>
-
-        <div className="form-row">
-            <div className="col form-group">
-                <label>Organization</label>
-                <Field name={names[6]}
-                       placeholder="organization"
-                       component={TextField}/>
-            </div>
-        </div>
     </div>
 )
 

--- a/src/main/typescript/lib/metadata/Contributor.ts
+++ b/src/main/typescript/lib/metadata/Contributor.ts
@@ -26,7 +26,7 @@ function toContributorRoleScheme(value: string): ContributorRoleScheme | undefin
     return Object.values(ContributorRoleScheme).find(v => v === value)
 }
 
-const creatorRole = "Creator"
+export const creatorRole = "Creator"
 const rightsholderRole = "RightsHolder"
 const rightsholderValue = "Rightsholder"
 

--- a/src/main/typescript/lib/metadata/Contributor.ts
+++ b/src/main/typescript/lib/metadata/Contributor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { emptySchemedValue, SchemedValue, schemedValueConverter, schemedValueDeconverter } from "./Value"
-import * as lodash from "lodash"
+import { partition } from "lodash"
 import { clean, emptyString, nonEmptyObject } from "./misc"
 import { DropdownListEntry } from "../../model/DropdownLists"
 
@@ -26,6 +26,7 @@ function toContributorRoleScheme(value: string): ContributorRoleScheme | undefin
     return Object.values(ContributorRoleScheme).find(v => v === value)
 }
 
+const creatorRole = "Creator"
 const rightsholderRole = "RightsHolder"
 const rightsholderValue = "Rightsholder"
 
@@ -46,6 +47,16 @@ export const emptyContributor: Contributor = {
     surname: emptyString,
     ids: [emptySchemedValue],
     role: emptyString,
+    organization: emptyString,
+}
+
+export const emptyCreator: Contributor = {
+    titles: emptyString,
+    initials: emptyString,
+    insertions: emptyString,
+    surname: emptyString,
+    ids: [emptySchemedValue],
+    role: creatorRole,
     organization: emptyString,
 }
 
@@ -92,6 +103,8 @@ const rightsHolderRoleDeconverter: (r: string) => any = r => clean({
     value: rightsholderValue,
 })
 
+export const splitCreatorsAndContributors: (cs: Contributor[]) => [Contributor[], Contributor[]] = cs => partition(cs, { role: creatorRole })
+
 export const contributorConverter: (ids: DropdownListEntry[], roles: DropdownListEntry[]) => (c: any) => Contributor = (ids, roles) => c => {
     return ({
         titles: c.titles || emptyString,
@@ -114,6 +127,27 @@ export const contributorDeconverter: (roles: DropdownListEntry[]) => (c: Contrib
     organization: c.organization,
 })
 
+export const creatorConverter: (ids: DropdownListEntry[]) => (c: any) => Contributor = ids => c => {
+    return ({
+        titles: c.titles || emptyString,
+        initials: c.initials || emptyString,
+        insertions: c.insertions || emptyString,
+        surname: c.surname || emptyString,
+        ids: c.ids ? c.ids.map(contributorSchemeIdConverter(ids)) : [emptySchemedValue],
+        role: creatorRole,
+        organization: c.organization || emptyString
+    })
+}
+
+export const creatorDeconverter: (c: Contributor) => any = c => clean({
+    titles: c.titles,
+    initials: c.initials,
+    insertions: c.insertions,
+    surname: c.surname,
+    ids: c.ids && c.ids.map(contributorSchemeIdDeconverter).filter(nonEmptyObject),
+    organization: c.organization,
+})
+
 export const rightsHolderDeconverter: (c: Contributor) => any = c => clean({
     titles: c.titles,
     initials: c.initials,
@@ -126,5 +160,5 @@ export const rightsHolderDeconverter: (c: Contributor) => any = c => clean({
 
 export const contributorsConverter: (ids: DropdownListEntry[], roles: DropdownListEntry[]) => (cs: any) => [Contributor[], Contributor[]] = (ids, roles) => cs => {
     const contributors: Contributor[] = cs.map(contributorConverter(ids, roles))
-    return lodash.partition(contributors, { role: "RightsHolder" })
+    return partition(contributors, { role: "RightsHolder" })
 }

--- a/src/main/typescript/lib/metadata/Identifier.ts
+++ b/src/main/typescript/lib/metadata/Identifier.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { SchemedValue, schemedValueConverter, schemedValueDeconverter } from "./Value"
-import * as lodash from "lodash"
+import {partition} from "lodash"
 import { DropdownListEntry } from "../../model/DropdownLists"
 
 enum IdentifierScheme {
@@ -58,7 +58,7 @@ const alternativeIdentifierConverter: (identifiers: DropdownListEntry[]) => (ai:
 export const alternativeIdentifersConverter: (identifiers: DropdownListEntry[]) => (ais: any[]) => [SchemedValue[], SchemedValue[]] = identifiers => ais => {
     const ids = ais.map(alternativeIdentifierConverter(identifiers))
 
-    return lodash.partition(ids, { scheme: archisZaakIdentificatie })
+    return partition(ids, { scheme: archisZaakIdentificatie })
 }
 
 export const alternativeIdentifierDeconverter: (ai: SchemedValue) => any = schemedValueDeconverter

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -16,6 +16,7 @@
 import { expect } from "chai"
 import { describe, it } from "mocha"
 import {
+    atLeastOneContributor,
     checkboxMustBeChecked,
     dateAvailableMustBeAfterDateCreated,
     mandatoryFieldArrayValidator,
@@ -24,6 +25,7 @@ import {
     mandatoryRadioButtonValidator,
 } from "../../../../main/typescript/components/form/Validation"
 import { PrivacySensitiveDataValue } from "../../../../main/typescript/lib/metadata/PrivacySensitiveData"
+import { Contributor, emptyContributor } from "../../../../main/typescript/lib/metadata/Contributor"
 
 describe("Validation", () => {
 
@@ -179,6 +181,45 @@ describe("Validation", () => {
                 dateCreated: new Date(2018, 11, 16),
                 dateAvailable: new Date(2018, 11, 15),
             })).to.eql("'Date available' cannot be a date earlier than 'Date created'")
+        })
+    })
+
+    describe("atLeastOneContributor", () => {
+        const contributor1: Contributor = {
+            initials: "D.A.",
+            surname: "N.S.",
+            ids: [
+                {
+                    scheme: "test",
+                    value: "foobar",
+                },
+                {
+                    scheme: "",
+                    value: "",
+                },
+                {},
+            ],
+        }
+        const contributor2: Contributor = {
+            organization: "K.N.A.W.",
+        }
+        const contributor3: Contributor = emptyContributor
+        const contributor4: Contributor = {}
+
+        it("should return undefined when at least one Contributor is not empty", () => {
+            expect(atLeastOneContributor([contributor1, contributor2, contributor3, contributor4])).to.be.undefined
+        })
+
+        it("should return an error when undefined is given", () => {
+            expect(atLeastOneContributor(undefined)).to.eql("no contributors were provided")
+        })
+
+        it("should return an error when an empty list is given", () => {
+            expect(atLeastOneContributor([])).to.eql("no contributors were provided")
+        })
+
+        it("should return an error when only empty Contributors are given", () => {
+            expect(atLeastOneContributor([contributor3, contributor4])).to.eql("no contributors were provided")
         })
     })
 })

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -24,6 +24,7 @@ import {
     mandatoryFieldValidator,
     mandatoryPrivacySensitiveDataValidator,
     mandatoryRadioButtonValidator,
+    validateContributors,
 } from "../../../../main/typescript/components/form/Validation"
 import { PrivacySensitiveDataValue } from "../../../../main/typescript/lib/metadata/PrivacySensitiveData"
 import { Contributor, creatorRole, emptyContributor } from "../../../../main/typescript/lib/metadata/Contributor"
@@ -248,6 +249,62 @@ describe("Validation", () => {
         it("should return an error when no Contributor has role 'Creator'", () => {
             expect(atLeastOneCreator([contributor1, contributor2, contributor3, contributor4]))
                 .to.eql("at least one creator is required")
+        })
+    })
+
+    describe("validateContributors", () => {
+        const contributor1: Contributor = {
+            initials: "D.A.",
+            surname: "N.S.",
+        }
+        const contributor2: Contributor = {
+            organization: "K.N.A.W.",
+        }
+        const contributor3: Contributor = emptyContributor
+        const contributor4: Contributor = {}
+
+        it("should return an empty array when an empty list is provided", () => {
+            expect(validateContributors([])).to.eql([])
+        })
+
+        it("should return empty objects when for each Contributor at least 'initials' and 'surname' are provided", () => {
+            expect(validateContributors([contributor1, contributor1])).to.eql([{}, {}])
+        })
+
+        it("should return empty objects when for each Contributor at least the 'organization' is provided", () => {
+            expect(validateContributors([contributor2, contributor2])).to.eql([{}, {}])
+        })
+
+        it("should return empty objects when for each Contributor at least either 'initials' and 'surname' or 'organization' are/is provided", () => {
+            expect(validateContributors([contributor1, contributor2])).to.eql([{}, {}])
+        })
+
+        it("should return an error object when 'initials', 'surname' and 'organization' are not provided", () => {
+            expect(validateContributors([contributor3])).to.eql([{
+                organization: "no organization given",
+                initials: "no initials given",
+                surname: "no surname given",
+            }])
+        })
+
+        it("should return an error object when an empty object is given", () => {
+            expect(validateContributors([contributor4])).to.eql([{
+                organization: "no organization given",
+                initials: "no initials given",
+                surname: "no surname given",
+            }])
+        })
+
+        it("should return an error object with only field 'surname' when only 'initials' is provided", () => {
+            expect(validateContributors([{initials: "D.A."}])).to.eql([{
+                surname: "no surname given",
+            }])
+        })
+
+        it("should return an error object with only field 'initials' when only 'surname' is provided", () => {
+            expect(validateContributors([{surname: "N.S."}])).to.eql([{
+                initials: "no initials given",
+            }])
         })
     })
 })

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -129,19 +129,15 @@ describe("Validation", () => {
     describe("checkboxMustBeChecked", () => {
 
         it("should return undefined when the value is true", () => {
-            expect(checkboxMustBeChecked(true)).to.be.undefined
+            expect(checkboxMustBeChecked(true, "hello world")).to.be.undefined
         })
 
         it("should return an error when the value is false", () => {
-            expect(checkboxMustBeChecked(false)).to.eql("Accept the license agreement before submitting this dataset")
-        })
-
-        it("should return an error when the value is something else than true", () => {
-            expect(checkboxMustBeChecked("hello")).to.eql("Accept the license agreement before submitting this dataset")
+            expect(checkboxMustBeChecked(false, "hello world")).to.eql("hello world")
         })
 
         it("should return an error when the value is undefined", () => {
-            expect(checkboxMustBeChecked(undefined)).to.eql("Accept the license agreement before submitting this dataset")
+            expect(checkboxMustBeChecked(undefined, "hello world")).to.eql("hello world")
         })
     })
 

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -17,6 +17,7 @@ import { expect } from "chai"
 import { describe, it } from "mocha"
 import {
     atLeastOneContributor,
+    atLeastOneCreator,
     checkboxMustBeChecked,
     dateAvailableMustBeAfterDateCreated,
     mandatoryFieldArrayValidator,
@@ -25,7 +26,7 @@ import {
     mandatoryRadioButtonValidator,
 } from "../../../../main/typescript/components/form/Validation"
 import { PrivacySensitiveDataValue } from "../../../../main/typescript/lib/metadata/PrivacySensitiveData"
-import { Contributor, emptyContributor } from "../../../../main/typescript/lib/metadata/Contributor"
+import { Contributor, creatorRole, emptyContributor } from "../../../../main/typescript/lib/metadata/Contributor"
 
 describe("Validation", () => {
 
@@ -201,6 +202,52 @@ describe("Validation", () => {
 
         it("should return an error when only empty Contributors are given", () => {
             expect(atLeastOneContributor([contributor3, contributor4])).to.eql("no contributors were provided")
+        })
+    })
+
+    describe("atLeastOneCreator", () => {
+        const contributor1: Contributor = {
+            initials: "D.A.",
+            surname: "N.S.",
+            ids: [
+                {
+                    scheme: "test",
+                    value: "foobar",
+                },
+                {
+                    scheme: "",
+                    value: "",
+                },
+                {},
+            ],
+        }
+        const contributor2: Contributor = {
+            organization: "K.N.A.W.",
+        }
+        const contributor3: Contributor = emptyContributor
+        const contributor4: Contributor = {}
+        const creator: Contributor = {
+            initials: "my",
+            surname: "name",
+            role: creatorRole,
+        }
+
+        it("should return undefined when at least one Contributor has role 'Creator'", () => {
+            expect(atLeastOneCreator([contributor1, contributor2, contributor3, contributor4, creator]))
+                .to.be.undefined
+        })
+
+        it("should return an error when undefined is given", () => {
+            expect(atLeastOneCreator(undefined)).to.eql("at least one creator is required")
+        })
+
+        it("should return an error when an empty list is given", () => {
+            expect(atLeastOneCreator([])).to.eql("at least one creator is required")
+        })
+
+        it("should return an error when no Contributor has role 'Creator'", () => {
+            expect(atLeastOneCreator([contributor1, contributor2, contributor3, contributor4]))
+                .to.eql("at least one creator is required")
         })
     })
 })

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -78,22 +78,22 @@ describe("Validation", () => {
     describe("mandatoryRadioButtonValidator", () => {
 
         it("should return undefined when the value is present", () => {
-            expect(mandatoryRadioButtonValidator({ "hello": "world" }, allValues, props, fieldName)).to.be.undefined
+            expect(mandatoryRadioButtonValidator({ "hello": "world" }, fieldName)).to.be.undefined
         })
 
         it("should return undefined when the object contains a mix of empty and non-empty values", () => {
             expect(mandatoryRadioButtonValidator({
                 "hello1": "world",
                 "hello2": "",
-            }, allValues, props, fieldName)).to.be.undefined
+            }, fieldName)).to.be.undefined
         })
 
         it("should return an error when the object contains only empty values", () => {
-            expect(mandatoryRadioButtonValidator({ "hello": "" }, allValues, props, fieldName)).to.eql(`no ${fieldName} was provided`)
+            expect(mandatoryRadioButtonValidator({ "hello": "" }, fieldName)).to.eql(`no ${fieldName} was chosen`)
         })
 
         it("should return an error when the value is undefined", () => {
-            expect(mandatoryRadioButtonValidator(undefined, allValues, props, fieldName)).to.eql(`no ${fieldName} was provided`)
+            expect(mandatoryRadioButtonValidator(undefined, fieldName)).to.eql(`no ${fieldName} was chosen`)
         })
     })
 
@@ -149,38 +149,24 @@ describe("Validation", () => {
     describe("dateAvailableMustBeAfterDateCreated", () => {
 
         it("should return undefined when dateCreated and dateAvailable are given and the latter is later than the former", () => {
-            expect(dateAvailableMustBeAfterDateCreated({}, {
-                dateCreated: new Date(2018, 11, 15),
-                dateAvailable: new Date(2018, 11, 16),
-            })).to.be.undefined
+            expect(dateAvailableMustBeAfterDateCreated(new Date(2018, 11, 15), new Date(2018, 11, 16))).to.be.undefined
         })
 
         it("should return undefined when dateCreated is undefined", () => {
-            expect(dateAvailableMustBeAfterDateCreated({}, {
-                dateCreated: undefined,
-                dateAvailable: new Date(2018, 11, 16),
-            })).to.be.undefined
+            expect(dateAvailableMustBeAfterDateCreated(undefined, new Date(2018, 11, 16))).to.be.undefined
         })
 
         it("should return undefined when dateAvailable is undefined", () => {
-            expect(dateAvailableMustBeAfterDateCreated({}, {
-                dateCreated: new Date(2018, 11, 15),
-                dateAvailable: undefined,
-            })).to.be.undefined
+            expect(dateAvailableMustBeAfterDateCreated(new Date(2018, 11, 15), undefined)).to.be.undefined
         })
 
         it("should return undefined when both dateCreated and dateAvailable are undefined", () => {
-            expect(dateAvailableMustBeAfterDateCreated({}, {
-                dateCreated: undefined,
-                dateAvailable: undefined,
-            })).to.be.undefined
+            expect(dateAvailableMustBeAfterDateCreated(undefined, undefined)).to.be.undefined
         })
 
         it("should return an error when dateCreated is later than dateAvailable", () => {
-            expect(dateAvailableMustBeAfterDateCreated({}, {
-                dateCreated: new Date(2018, 11, 16),
-                dateAvailable: new Date(2018, 11, 15),
-            })).to.eql("'Date available' cannot be a date earlier than 'Date created'")
+            expect(dateAvailableMustBeAfterDateCreated(new Date(2018, 11, 16), new Date(2018, 11, 15)))
+                .to.eql("'Date available' cannot be a date earlier than 'Date created'")
         })
     })
 

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -36,42 +36,42 @@ describe("Validation", () => {
     describe("mandatoryFieldValidator", () => {
 
         it("should return undefined when value is present", () => {
-            expect(mandatoryFieldValidator("hello", allValues, props, fieldName)).to.be.undefined
+            expect(mandatoryFieldValidator("hello", fieldName)).to.be.undefined
         })
 
         it("should return undefined when value is anything else than a string", () => {
-            expect(mandatoryFieldValidator(["hello", "array"], allValues, props, fieldName)).to.be.undefined
+            expect(mandatoryFieldValidator(["hello", "array"], fieldName)).to.be.undefined
         })
 
         it("should return an error when the value is empty", () => {
-            expect(mandatoryFieldValidator("", allValues, props, fieldName)).to.eql(`no ${fieldName} was provided`)
+            expect(mandatoryFieldValidator("", fieldName)).to.eql(`no ${fieldName} was provided`)
         })
 
         it("should return an error when the value is undefined", () => {
-            expect(mandatoryFieldValidator(undefined, allValues, props, fieldName)).to.eql(`no ${fieldName} was provided`)
+            expect(mandatoryFieldValidator(undefined, fieldName)).to.eql(`no ${fieldName} was provided`)
         })
     })
 
     describe("mandatoryFieldArrayValidator", () => {
 
         it("should return undefined when values are present", () => {
-            expect(mandatoryFieldArrayValidator(["hello", "array"], allValues, props, fieldName)).to.be.undefined
+            expect(mandatoryFieldArrayValidator(["hello", "array"], fieldName)).to.be.undefined
         })
 
         it("should return undefined when the array contains a mix of empty and non-empty values", () => {
-            expect(mandatoryFieldArrayValidator(["hello", "", "array"], allValues, props, fieldName)).to.be.undefined
+            expect(mandatoryFieldArrayValidator(["hello", "", "array"], fieldName)).to.be.undefined
         })
 
         it("should return an error when the array is empty", () => {
-            expect(mandatoryFieldArrayValidator([], allValues, props, fieldName)).to.eql(`no ${fieldName} were provided`)
+            expect(mandatoryFieldArrayValidator([], fieldName)).to.eql(`no ${fieldName} were provided`)
         })
 
         it("should return an error when the array only contains empty values", () => {
-            expect(mandatoryFieldArrayValidator(["", "", ""], allValues, props, fieldName)).to.eql(`no ${fieldName} were provided`)
+            expect(mandatoryFieldArrayValidator(["", "", ""], fieldName)).to.eql(`no ${fieldName} were provided`)
         })
 
         it("should return an error when the array is undefined", () => {
-            expect(mandatoryFieldArrayValidator(undefined, allValues, props, fieldName)).to.eql(`no ${fieldName} were provided`)
+            expect(mandatoryFieldArrayValidator(undefined, fieldName)).to.eql(`no ${fieldName} were provided`)
         })
     })
 

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -29,8 +29,6 @@ import { Contributor, emptyContributor } from "../../../../main/typescript/lib/m
 
 describe("Validation", () => {
 
-    const allValues = {}
-    const props = {}
     const fieldName = "my-field-name"
 
     describe("mandatoryFieldValidator", () => {
@@ -100,30 +98,31 @@ describe("Validation", () => {
     describe("mandatoryPrivacySensitiveDataValidator", () => {
 
         it("should return undefined when the value is a non-empty string", () => {
-            expect(mandatoryPrivacySensitiveDataValidator(PrivacySensitiveDataValue.YES, allValues, props, fieldName)).to.be.undefined
+            expect(mandatoryPrivacySensitiveDataValidator(PrivacySensitiveDataValue.YES)).to.be.undefined
         })
 
         it("should return undefined when the value is an object with a mix of empty and non-empty values", () => {
-            expect(mandatoryPrivacySensitiveDataValidator({
-                "hello1": "world",
-                "hello2": "",
-            }, allValues, props, fieldName)).to.be.undefined
+            expect(mandatoryPrivacySensitiveDataValidator({ "hello1": "world", "hello2": "", })).to.be.undefined
         })
 
         it("should return an error when the value is a string that is empty", () => {
-            expect(mandatoryPrivacySensitiveDataValidator("", allValues, props, fieldName)).to.eql(`no ${fieldName} was provided`)
+            expect(mandatoryPrivacySensitiveDataValidator(""))
+                .to.eql("please determine whether privacy sensitive data is present in this deposit")
         })
 
         it("should return an error when the value is a string that represents PrivacySensitiveDataValue.UNSPECIFIED", () => {
-            expect(mandatoryPrivacySensitiveDataValidator(PrivacySensitiveDataValue.UNSPECIFIED, allValues, props, fieldName)).to.eql(`no ${fieldName} was provided`)
+            expect(mandatoryPrivacySensitiveDataValidator(PrivacySensitiveDataValue.UNSPECIFIED))
+                .to.eql("please determine whether privacy sensitive data is present in this deposit")
         })
 
         it("should return an error when the value is an object with only empty values", () => {
-            expect(mandatoryPrivacySensitiveDataValidator({ "hello": "" }, allValues, props, fieldName)).to.eql(`no ${fieldName} was provided`)
+            expect(mandatoryPrivacySensitiveDataValidator({ "hello": "" }))
+                .to.eql("please determine whether privacy sensitive data is present in this deposit")
         })
 
         it("should return an error when the value is undefined", () => {
-            expect(mandatoryPrivacySensitiveDataValidator(undefined, allValues, props, fieldName)).to.eql(`no ${fieldName} was provided`)
+            expect(mandatoryPrivacySensitiveDataValidator(undefined))
+                .to.eql("please determine whether privacy sensitive data is present in this deposit")
         })
     })
 

--- a/src/test/typescript/mockserver/metadata.ts
+++ b/src/test/typescript/mockserver/metadata.ts
@@ -274,11 +274,6 @@ export const allfields: Metadata = {
                     value: "abcdef",
                 },
             ],
-            role: {
-                scheme: ContributorRoleSchemeValues.contributorType,
-                key: ContributorRoleKeyValues.DataCollector,
-                value: "Data collector",
-            },
             organization: "KNAW",
         },
         {


### PR DESCRIPTION
Fixes EASY-1767

#### When applied it will
* merge the creator/contributor fields
* add validation for the new contributor fields
* move general form validation to the root of the form (1 function, to keep all validation consistent and not mix 2 methods)

@DANS-KNAW/easy for review

![image](https://user-images.githubusercontent.com/5938204/48842542-d50ad600-ed94-11e8-96d5-156068c49ec5.png)

![image](https://user-images.githubusercontent.com/5938204/48842560-e05e0180-ed94-11e8-9656-892f85a0b807.png)

![image](https://user-images.githubusercontent.com/5938204/48842567-e2c05b80-ed94-11e8-93dd-cbcf4e4e4c44.png)

![image](https://user-images.githubusercontent.com/5938204/48842580-e8b63c80-ed94-11e8-86bb-6abeab18906c.png)

![image](https://user-images.githubusercontent.com/5938204/48842586-ef44b400-ed94-11e8-93b6-12297bf3aa1c.png)

![image](https://user-images.githubusercontent.com/5938204/48842600-f370d180-ed94-11e8-8553-b038d4b3c937.png)

![image](https://user-images.githubusercontent.com/5938204/48842607-f66bc200-ed94-11e8-8be6-dcf230eccbbd.png)

![image](https://user-images.githubusercontent.com/5938204/48842631-04b9de00-ed95-11e8-9e9c-da13e0566d7b.png)