### PR TITLE
NO JIRA. Renamed Checksum heading

### DIFF
--- a/src/main/typescript/components/form/parts/fileUpload/overview/FilesTableHead.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/overview/FilesTableHead.tsx
@@ -20,7 +20,7 @@ const FilesTableHead = () => (
     <tr className="row ml-0 mr-0 text-white">
         {/* these column sizes need to match with the sizes in FilesTableRow */}
         <th className="col-10 col-sm-11 col-md-5" scope="col">File</th>
-        <th className="col-12 col-sm-12 col-md-6" scope="col">Checksum</th>
+        <th className="col-12 col-sm-12 col-md-6" scope="col">SHA-1 checksum</th>
         <th className="col-2  col-sm-1  col-md-1" scope="col" id="actions_cell"/>
     </tr>
     </thead>


### PR DESCRIPTION
NO JIRA. Renamed the column header "Checksum" to "SHA-1 checksum". Even though @rvanheest rightly remarked that this column is probably not very informative to most users it needs to stay for the moment, as it is at least a way for the user to verify that the uploaded files were received correctly. For this purpose the checksum algorithm used is indispensable.

#### Where should the reviewer @DANS-KNAW/easy start?
One line
