### PR TITLE
EASY-1824: empty deposit table row

### DIFF
--- a/src/main/typescript/components/overview/DepositOverview.tsx
+++ b/src/main/typescript/components/overview/DepositOverview.tsx
@@ -26,6 +26,7 @@ import DepositTableHead from "./DepositTableHead"
 import DepositTableRow from "./DepositTableRow"
 import { Alert, CloseableWarning, ReloadAlert } from "../Errors"
 import { depositFormRoute } from "../../constants/clientRoutes"
+import EmptyDepositTableRow from "./EmptyDepositTableRow"
 
 function isEditable({ state }: Deposit): boolean {
     return state === DepositState.DRAFT || state === DepositState.REJECTED
@@ -118,19 +119,22 @@ class DepositOverview extends Component<DepositOverviewProps> {
 
     private renderTable() {
         const { deposits: { deposits, deleting } } = this.props
+        const depositIds = Object.keys(deposits)
 
         return (
             <table className="table table-striped deposit_table">
                 <DepositTableHead/>
-                <tbody>{Object.keys(deposits).map(depositId => {
-                    const editable = isEditable(deposits[depositId])
-                    return <DepositTableRow key={depositId}
-                                            deposit={deposits[depositId]}
-                                            deleting={deleting[depositId]}
-                                            deleteDeposit={this.deleteDeposit(depositId)}
-                                            editable={editable}
-                                            enterDeposit={this.enterDeposit(editable, depositId)}/>
-                })}</tbody>
+                <tbody>{depositIds.length == 0
+                    ? <EmptyDepositTableRow/>
+                    : depositIds.map(depositId => {
+                        const editable = isEditable(deposits[depositId])
+                        return <DepositTableRow key={depositId}
+                                                deposit={deposits[depositId]}
+                                                deleting={deleting[depositId]}
+                                                deleteDeposit={this.deleteDeposit(depositId)}
+                                                editable={editable}
+                                                enterDeposit={this.enterDeposit(editable, depositId)}/>
+                    })}</tbody>
             </table>
         )
     }

--- a/src/main/typescript/components/overview/EmptyDepositTableRow.tsx
+++ b/src/main/typescript/components/overview/EmptyDepositTableRow.tsx
@@ -17,7 +17,7 @@ import * as React from "react"
 
 const EmptyDepositTableRow = () => (
     <tr className="row ml-0 mr-0">
-        <td className="col col-12" scope="row" colSpan={5}>No deposits found</td>
+        <td className="col col-12" scope="row" colSpan={5}>No deposits yet</td>
     </tr>
 )
 

--- a/src/main/typescript/components/overview/EmptyDepositTableRow.tsx
+++ b/src/main/typescript/components/overview/EmptyDepositTableRow.tsx
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import * as React from "react"
 
 const EmptyDepositTableRow = () => (

--- a/src/main/typescript/components/overview/EmptyDepositTableRow.tsx
+++ b/src/main/typescript/components/overview/EmptyDepositTableRow.tsx
@@ -1,0 +1,9 @@
+import * as React from "react"
+
+const EmptyDepositTableRow = () => (
+    <tr className="row ml-0 mr-0">
+        <td className="col col-12" scope="row" colSpan={5}>No deposits found</td>
+    </tr>
+)
+
+export default EmptyDepositTableRow


### PR DESCRIPTION
Fixes EASY-1824

#### When applied it will
* show a row with "_no deposits found_" when no deposits have been made by a depositor

@DANS-KNAW/easy for review

![image](https://user-images.githubusercontent.com/5938204/49148453-b7df8580-f307-11e8-9f88-97acdf99bdd0.png)
