### PR TITLE
EASY-1718: show less licenses

### DIFF
--- a/src/main/resources/css/form.css
+++ b/src/main/resources/css/form.css
@@ -213,6 +213,7 @@
     color: var(--dark-hover);
 }
 
-.input-element .license-field .show-more:hover {
+.input-element .license-field .show-more:hover,
+.input-element .license-field .show-less:hover {
     cursor: pointer;
 }

--- a/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
@@ -50,6 +50,19 @@ class LicenseChoices extends Component<FieldProps & LicenseChoicesProps, License
         }
     }
 
+    showLessLicenses: () => void = () => {
+        switch (this.state.showCount) {
+            case 1:
+                break
+            case 3:
+                this.setState(prevState => ({ ...prevState, showCount: 1 }))
+                break
+            default:
+                this.setState(prevState => ({ ...prevState, showCount: 3 }))
+                break
+        }
+    }
+
     radioChoice = (text: string, link: string) => (
         <span><a className="external-link" href={link} target="_blank"><i className="fas fa-external-link-square-alt"/></a> {text}</span>
     )
@@ -81,12 +94,17 @@ class LicenseChoices extends Component<FieldProps & LicenseChoicesProps, License
             <div className={`license-field ${this.props.className || ""}`}>
                 <RadioChoicesInput {...this.props} divClassName="radio-choices" choices={this.choices()}/>
                 {this.props.choices.length >= this.state.showCount && this.renderShowMore()}
+                {this.props.choices.length <= this.state.showCount && this.renderShowLess()}
             </div>
         )
     }
 
     private renderShowMore() {
         return <a className="show-more" onClick={this.showMoreLicenses}>show more...</a>
+    }
+
+    private renderShowLess() {
+        return <a className="show-less" onClick={this.showLessLicenses}>show less...</a>
     }
 }
 


### PR DESCRIPTION
part of EASY-1718

#### When applied it will
* add a way to show less licenses when all licenses are shown

@DANS-KNAW/easy for review

_before clicking_
![image](https://user-images.githubusercontent.com/5938204/49150584-a0a39680-f30d-11e8-81a5-4f6ab34039c9.png)

_after clicking_
![image](https://user-images.githubusercontent.com/5938204/49150650-d2b4f880-f30d-11e8-8003-97c764b8c757.png)

