### PR TITLE
EASY-1718: dependent accessright and license fields

### DIFF
--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -159,7 +159,5 @@ export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFo
     // accept license agreement
     errors.acceptLicenseAgreement = checkboxMustBeChecked(values.acceptLicenseAgreement, "Accept the license agreement before submitting this dataset")
 
-    console.log("errors", errors)
-
     return errors
 }

--- a/src/main/typescript/components/form/parts/LicenseAndAccessForm.tsx
+++ b/src/main/typescript/components/form/parts/LicenseAndAccessForm.tsx
@@ -16,19 +16,17 @@
 import * as React from "react"
 import TextFieldArray from "../../../lib/formComponents/TextFieldArray"
 import { RepeatableField, RepeatableFieldWithDropdown } from "../../../lib/formComponents/ReduxFormUtils"
-import { Field } from "redux-form"
+import { Field, Fields } from "redux-form"
 import { Contributor, emptyContributor } from "../../../lib/metadata/Contributor"
 import { AccessRight } from "../../../lib/metadata/AccessRight"
 import { emptyString } from "../../../lib/metadata/misc"
-import LicenseField from "./licenseAndAccess/LicenseField"
 import { AppState } from "../../../model/AppState"
 import { connect } from "react-redux"
 import { DropdownList } from "../../../model/DropdownLists"
 import RightsholderFields from "./licenseAndAccess/RightsholderFields"
 import DatePickerField from "../../../lib/formComponents/DatePickerField"
 import * as moment from "moment"
-import AccessRightsField from "./licenseAndAccess/AccessRightsField"
-import { dateAvailableMustBeAfterDateCreated, mandatoryRadioButtonValidator } from "../Validation"
+import AccessRightsAndLicenseFields from "./licenseAndAccess/AccessRightsAndLicenseFields"
 
 export interface LicenseAndAccessFormData {
     rightsHolders?: Contributor[]
@@ -68,19 +66,9 @@ const LicenseAndAccessForm = ({ licenses, contributorIds }: LicenseAndAccessForm
                          fieldNames={[(name: string) => name]}
                          component={TextFieldArray}/>
 
-        <Field name="accessRights"
-               label="Access rights"
-               mandatory
-               helpText
-               component={AccessRightsField}/>
-
-        <Field name="license"
-               label="License"
-               mandatory
-               helpText
-               withEmptyDefault
-               dropdown={licenses}
-               component={LicenseField}/>
+        <Fields names={["accessRights", "license"]}
+                dropDown={{ licenses: licenses }}
+                component={AccessRightsAndLicenseFields}/>
 
         <Field name="dateAvailable"
                label="Date available"

--- a/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsAndLicenseFields.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsAndLicenseFields.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import { change } from "redux-form"
+import LicenseField from "./LicenseField"
+import AccessRightsField from "./AccessRightsField"
+import { FieldProps } from "../../../../lib/formComponents/ReduxFormUtils"
+import { InnerComponentProps } from "../../../../lib/formComponents/FieldHOC"
+import { DropdownList } from "../../../../model/DropdownLists"
+import { AccessRightValue } from "../../../../lib/metadata/AccessRight"
+import { depositFormName } from "../../../../constants/depositFormConstants"
+import { Dispatch } from "redux"
+import { dansLicense, emptyLicense } from "../../../../lib/metadata/License"
+
+const dansLicenseDropdownList: DropdownList = {
+    list: [dansLicense],
+    state: {
+        fetchingList: false,
+        fetchedList: true,
+    },
+}
+
+const noLicenses: DropdownList = {
+    list: [],
+    state: {
+        fetchingList: false,
+        fetchedList: true,
+    },
+}
+
+interface AccessRightsAndLicenseFieldsProps {
+    names: string[]
+    accessRights: FieldProps & InnerComponentProps
+    license: FieldProps & InnerComponentProps
+    dropDown: { licenses: DropdownList }
+}
+
+class AccessRightsAndLicenseFields extends React.Component<AccessRightsAndLicenseFieldsProps> {
+    onAccessRightChange = (dispatch: Dispatch<any>, license: string, licenseName: string) => () => {
+        license !== emptyLicense && dispatch(change(depositFormName, licenseName, emptyLicense))
+    }
+
+    render() {
+        const { names: [accessRightName, licenseName], accessRights, license, dropDown: { licenses: licensesDropdowns } } = this.props
+        const accessRightsCategory = accessRights.input.value.category
+        const licenseChoices = accessRightsCategory == AccessRightValue.OPEN_ACCESS
+            ? licensesDropdowns
+            : accessRightsCategory == AccessRightValue.REQUEST_PERMISSION
+                ? dansLicenseDropdownList
+                : noLicenses
+
+        return (
+            <div>
+                <AccessRightsField name={accessRightName}
+                                   label="Access rights"
+                                   mandatory
+                                   helpText
+                                   onAccessRightChange={this.onAccessRightChange(accessRights.meta.dispatch, license.input.value, licenseName)}
+                                   {...accessRights}/>
+
+                <LicenseField name={licenseName}
+                              label="License"
+                              mandatory
+                              helpText
+                              withEmptyDefault
+                              dropdown={licenseChoices}
+                              {...license}/>
+            </div>
+        )
+    }
+}
+
+export default AccessRightsAndLicenseFields

--- a/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsAndLicenseFields.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsAndLicenseFields.tsx
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import * as React from "react"
 import { change } from "redux-form"
 import LicenseField from "./LicenseField"

--- a/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 import * as React from "react"
-import { Field } from "redux-form"
+import { ChangeEvent } from "react"
+import { EventWithDataHandler, Field } from "redux-form"
 import { AccessRightValue } from "../../../../lib/metadata/AccessRight"
 import asField, { InnerComponentProps } from "../../../../lib/formComponents/FieldHOC"
 import { RadioChoicesInput } from "../../../../lib/formComponents/RadioChoices"
 import { FieldProps } from "../../../../lib/formComponents/ReduxFormUtils"
 
-const AccessRightsField = ({ input, className }: FieldProps & InnerComponentProps ) => {
+interface AccessRightsFieldOwnProps {
+    onAccessRightChange: EventWithDataHandler<ChangeEvent<any>>
+}
 
+type AccessRightsFieldProps = FieldProps & InnerComponentProps & AccessRightsFieldOwnProps
+
+const AccessRightsField = ({ input, className, onAccessRightChange }: AccessRightsFieldProps) => {
     const choices = [
         {
             title: AccessRightValue.OPEN_ACCESS,
@@ -39,6 +45,7 @@ const AccessRightsField = ({ input, className }: FieldProps & InnerComponentProp
                 <Field name={`${input.name}.category`}
                        divClassName="radio-button"
                        choices={choices}
+                       onChange={onAccessRightChange}
                        component={RadioChoicesInput}/>
             </div>
         </div>

--- a/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
@@ -98,14 +98,14 @@ class LicenseChoices extends Component<FieldProps & LicenseChoicesProps, License
             this.setState(prevState => ({ ...prevState, showCount: 1 }))
 
         const choices = this.choices()
-        return choices.length === 0 ? this.renderNoLicenses() : this.renderLicenses(choices)
+        return choices.length === 0 ? LicenseChoices.renderNoLicenses() : this.renderLicenses(choices)
     }
 
-    private renderNoLicenses() {
+    private static renderNoLicenses() {
         return (
-            <div className={`license-field ${this.props.className || ""}`}>
+            <label className="mb-0" style={{ paddingTop: "5px" }}>
                 <i>Choose an accessright first</i>
-            </div>
+            </label>
         )
     }
 

--- a/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
@@ -93,8 +93,8 @@ class LicenseChoices extends Component<FieldProps & LicenseChoicesProps, License
         return (
             <div className={`license-field ${this.props.className || ""}`}>
                 <RadioChoicesInput {...this.props} divClassName="radio-choices" choices={this.choices()}/>
-                {this.props.choices.length >= this.state.showCount && this.renderShowMore()}
-                {this.props.choices.length <= this.state.showCount && this.renderShowLess()}
+                {this.props.choices.length > this.state.showCount && this.renderShowMore()}
+                {this.props.choices.length < this.state.showCount && this.renderShowLess()}
             </div>
         )
     }

--- a/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/LicenseField.tsx
@@ -30,6 +30,8 @@ interface LicenseChoicesState {
     showCount: number
 }
 
+type Choice = { title: string, value: any }
+
 class LicenseChoices extends Component<FieldProps & LicenseChoicesProps, LicenseChoicesState> {
     constructor(props: FieldProps & LicenseChoicesProps) {
         super(props)
@@ -67,7 +69,7 @@ class LicenseChoices extends Component<FieldProps & LicenseChoicesProps, License
         <span><a className="external-link" href={link} target="_blank"><i className="fas fa-external-link-square-alt"/></a> {text}</span>
     )
 
-    choices() {
+    choices(): Choice[] {
         const value = this.props.input.value
         const actualChoices = this.props.choices.slice(0, this.state.showCount).map(entry => ({
             title: entry.key,
@@ -86,13 +88,31 @@ class LicenseChoices extends Component<FieldProps & LicenseChoicesProps, License
         return actualChoices
     }
 
+    componentDidUpdate(prevProps: FieldProps & LicenseChoicesProps) {
+        if (prevProps.choices !== this.props.choices)
+            this.setState(prevState => ({ ...prevState, showCount: 1 }))
+    }
+
     render() {
         if (this.state.showCount < 1)
             this.setState(prevState => ({ ...prevState, showCount: 1 }))
 
+        const choices = this.choices()
+        return choices.length === 0 ? this.renderNoLicenses() : this.renderLicenses(choices)
+    }
+
+    private renderNoLicenses() {
         return (
             <div className={`license-field ${this.props.className || ""}`}>
-                <RadioChoicesInput {...this.props} divClassName="radio-choices" choices={this.choices()}/>
+                <i>Choose an accessright first</i>
+            </div>
+        )
+    }
+
+    private renderLicenses(choices: Choice[]) {
+        return (
+            <div className={`license-field ${this.props.className || ""}`}>
+                <RadioChoicesInput {...this.props} divClassName="radio-choices" choices={choices}/>
                 {this.props.choices.length > this.state.showCount && this.renderShowMore()}
                 {this.props.choices.length < this.state.showCount && this.renderShowLess()}
             </div>
@@ -118,7 +138,7 @@ interface LicenseFieldInputProps {
 
 type LicenseFieldProps = FieldProps & SelectHTMLAttributes<HTMLSelectElement> & LicenseFieldInputProps
 
-const LicenseField = ({ dropdown: {state, list}, ...props}: LicenseFieldProps) => (
+const LicenseField = ({ dropdown: { state, list }, ...props }: LicenseFieldProps) => (
     <LoadDropdownData state={state}>
         <LicenseChoicesField {...props} choices={list}/>
     </LoadDropdownData>

--- a/src/main/typescript/lib/metadata/License.ts
+++ b/src/main/typescript/lib/metadata/License.ts
@@ -18,6 +18,12 @@ import { emptyString } from "./misc"
 
 export const emptyLicense = emptyString
 
+export const dansLicense: DropdownListEntry = {
+    key: "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSlicenceagreementUK5.3DEF.pdf",
+    value: "DANS LICENSE",
+    displayValue: "DANS LICENSE",
+}
+
 export const licenseConverter: (licenses: DropdownListEntry[]) => (l: any) => string = licenses => l => {
     const validLicense = licenses.find(({ key }) => key === l)
 
@@ -28,7 +34,7 @@ export const licenseConverter: (licenses: DropdownListEntry[]) => (l: any) => st
 }
 
 export const licenseDeconverter: (licenses: DropdownListEntry[]) => (l: string) => any = licenses => l => {
-    const validLicense = licenses.find(({key}) => key === l)
+    const validLicense = dansLicense.key === l || licenses.find(({ key }) => key === l)
 
     if (validLicense)
         return l

--- a/src/main/typescript/lib/metadata/License.ts
+++ b/src/main/typescript/lib/metadata/License.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 import { DropdownListEntry } from "../../model/DropdownLists"
+import { emptyString } from "./misc"
+
+export const emptyLicense = emptyString
 
 export const licenseConverter: (licenses: DropdownListEntry[]) => (l: any) => string = licenses => l => {
     const validLicense = licenses.find(({ key }) => key === l)

--- a/src/main/typescript/lib/metadata/License.ts
+++ b/src/main/typescript/lib/metadata/License.ts
@@ -25,7 +25,7 @@ export const dansLicense: DropdownListEntry = {
 }
 
 export const licenseConverter: (licenses: DropdownListEntry[]) => (l: any) => string = licenses => l => {
-    const validLicense = licenses.find(({ key }) => key === l)
+    const validLicense = dansLicense.key === l || licenses.find(({ key }) => key === l)
 
     if (validLicense)
         return l

--- a/src/main/typescript/lib/metadata/Metadata.ts
+++ b/src/main/typescript/lib/metadata/Metadata.ts
@@ -49,7 +49,7 @@ import {
     PrivacySensitiveDataValue,
 } from "./PrivacySensitiveData"
 import { emptyQualifiedSchemedValue, emptySchemedValue } from "./Value"
-import { licenseConverter, licenseDeconverter } from "./License"
+import { emptyLicense, licenseConverter, licenseDeconverter } from "./License"
 import { emptyRelation, relatedIdentifierDeconverter, relationDeconverter, relationsConverter } from "./Relation"
 import { clean, emptyString, isEmptyString, nonEmptyObject, normalizeEmpty } from "./misc"
 import { cmdiFormatDeconverter, formatDeconverter, formatsConverter, imtFormatDeconverter } from "./Format"
@@ -106,7 +106,7 @@ export const metadataConverter: (input: any, dropDowns: DropdownLists) => Deposi
         : { category: undefined }
     const license = input.license
         ? licenseConverter(dropDowns.licenses.list)(input.license)
-        : emptyString
+        : emptyLicense
     const [dcmiTypes, normalTypes] = input.types
         ? typesConverter(dropDowns.dcmiTypes.list)(input.types)
         : [[], []]


### PR DESCRIPTION
Fixes EASY-1718

#### When applied it will
* make the accessright and license fields dependent

@DANS-KNAW/easy for review

_Starting with a pre-filled form, it all looks like it did before..._
![image](https://user-images.githubusercontent.com/5938204/49282706-1e8fab00-f490-11e8-8efd-961b357b71f7.png)

_... you can still click the 'show more' button..._
![image](https://user-images.githubusercontent.com/5938204/49282729-2cddc700-f490-11e8-9804-92c910e003c9.png)

_... as well as the 'show less' button._
![image](https://user-images.githubusercontent.com/5938204/49282742-3404d500-f490-11e8-86e6-c3e8e991c018.png)

_When choosing 'Restricted Access', you get the DANS license as the only choice._
![image](https://user-images.githubusercontent.com/5938204/49282763-3ebf6a00-f490-11e8-87f6-5daf5719a0f7.png)

_Every time you change the access right, the license gets reset._
![image](https://user-images.githubusercontent.com/5938204/49282788-4bdc5900-f490-11e8-98bf-4f99c9cc4f6d.png)
![image](https://user-images.githubusercontent.com/5938204/49282805-539bfd80-f490-11e8-85f7-868316e419b4.png)

_Please note that the red warning is only shown when you had already chosen a license before you changed the access right_
![image](https://user-images.githubusercontent.com/5938204/49283129-2e5bbf00-f491-11e8-858f-430bc5a68ded.png)
![image](https://user-images.githubusercontent.com/5938204/49283117-2734b100-f491-11e8-90e8-6a886a582a35.png)

_When opening up a new deposit, no license can be chosen until you specify the access right_
![image](https://user-images.githubusercontent.com/5938204/49283608-74fde900-f492-11e8-9fc8-c94967e380db.png)
