### PR TITLE
EASY-1815: FileUpload posts to the correct URL

### DIFF
--- a/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
@@ -26,7 +26,7 @@ import { Files } from "../../../../../model/FileInfo"
 
 interface FileUploaderProps {
     depositId: DepositId
-    fileUploadUrl: (filePath: string) => string
+    fileUploadUrl: string
 
     fetchFiles: (depositId: DepositId) => ThunkAction<FetchAction<Files>>
 }
@@ -74,7 +74,7 @@ class FileUploader extends Component<FileUploaderProps, FileUploaderState> {
                 </div>
                 <div className="col col-12 col-sm-12 col-md-9">
                     <FileLoader file={this.state.uploadingFile || null}
-                                url={this.state.uploadingFile ? this.props.fileUploadUrl(this.state.uploadingFile.name) : "#"}
+                                url={this.props.fileUploadUrl}
                                 preventReload
                                 showCancelBtn
                                 onUploadFinished={this.uploadFinished}/>
@@ -86,7 +86,7 @@ class FileUploader extends Component<FileUploaderProps, FileUploaderState> {
 
 const mapStateToProps = (state: AppState) => ({
     depositId: state.depositForm.depositId,
-    fileUploadUrl: (filePath: string) => uploadFileUrl(state.depositForm.depositId!, filePath)(state),
+    fileUploadUrl: uploadFileUrl(state.depositForm.depositId!, "")(state),
 })
 
 export default connect(mapStateToProps, { fetchFiles })(FileUploader)

--- a/src/test/typescript/mockserver/db.ts
+++ b/src/test/typescript/mockserver/db.ts
@@ -192,16 +192,18 @@ export const getFilesListing: (id: DepositId) => FileInfo[] | undefined = id => 
 
 export const addFile: (id: DepositId, dirPath: string, filename: string) => boolean = (id, dirPath, filename) => {
     const deposit = data[id]
-    const files = deposit.files
+    if (deposit) {
+        const files = deposit.files
 
-    if (deposit && files) {
-        const newFile: FileInfo = {
-            filename: filename,
-            dirpath: dirPath,
-            sha1sum: "unknown",
+        if (files) {
+            const newFile: FileInfo = {
+                filename: filename,
+                dirpath: dirPath,
+                sha1sum: "unknown",
+            }
+            data = { ...data, [id]: { ...deposit, files: [...files, newFile] } }
+            return true
         }
-        data = { ...data, [id]: { ...deposit, files: [...files, newFile] } }
-        return true
     }
     return false
 }

--- a/src/test/typescript/mockserver/server.ts
+++ b/src/test/typescript/mockserver/server.ts
@@ -207,13 +207,12 @@ app.get("/deposit/:id/file/:dir_path*?", (req: Request, res: Response) => {
         }
     }
 })
-// TODO This implementation is not according to the specs!!!
 app.post("/deposit/:id/file/:dir_path*?", async (req: Request, res: Response) => {
     const depositId = req.params.id
     const dir_path = req.params.dir_path
     const restPath = req.params[0]
-    const dirPath = dir_path && restPath ? dir_path + restPath : dir_path
-    console.log(`POST /deposit/${depositId}/file${dirPath ? `/${dirPath}` : ""}`)
+    const dirPath = dir_path && restPath ? dir_path + restPath : (dir_path || "")
+    console.log(`POST /deposit/${depositId}/file/${dirPath}`)
 
     if (!req.files)
         return res.status(400).send("No files were uploaded.")
@@ -224,14 +223,10 @@ app.post("/deposit/:id/file/:dir_path*?", async (req: Request, res: Response) =>
                 const uploadedFile = file as UploadedFile
 
                 return new Promise<string>((resolve, reject) => {
-                    const dirPartOfDirPath = dirPath === uploadedFile.name // if it is uploaded to the root directory
-                        ? ""
-                        : dirPath.replace(new RegExp(`/${uploadedFile.name}$`), "")
-
                     uploadedFile.mv(`./target/build-mockserver/${uploadedFile.name}`, err => {
                         if (err)
                             return reject(err)
-                        else if (addFile(depositId, "/" + dirPartOfDirPath, uploadedFile.name))
+                        else if (addFile(depositId, "/" + dirPath, uploadedFile.name))
                             resolve(uploadedFile.name)
                         else
                             return reject(err)


### PR DESCRIPTION
Fixes EASY-1815

#### When applied it will
* post files to the correct URL (not with filename postfix, but to the root directory of the deposit)

@DANS-KNAW/easy for review