### PR TITLE
EASY-1820 rename: acceptLicenseAgreement --> acceptDepositAgreement

### DIFF
--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -156,8 +156,8 @@ export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFo
     // privacy sensitive data form
     errors.privacySensitiveDataPresent = mandatoryPrivacySensitiveDataValidator(values.privacySensitiveDataPresent)
 
-    // accept license agreement
-    errors.acceptLicenseAgreement = checkboxMustBeChecked(values.acceptLicenseAgreement, "Accept the license agreement before submitting this dataset")
+    // accept deposit agreement
+    errors.acceptDepositAgreement = checkboxMustBeChecked(values.acceptDepositAgreement, "Accept the deposit agreement before submitting this dataset")
 
     return errors
 }

--- a/src/main/typescript/components/form/parts/DepositLicenseForm.tsx
+++ b/src/main/typescript/components/form/parts/DepositLicenseForm.tsx
@@ -20,7 +20,7 @@ import Mandatory from "../../../lib/formComponents/Mandatory"
 import { checkboxMustBeChecked } from "../Validation"
 
 export interface DepositLicenseFormData {
-    acceptLicenseAgreement?: boolean
+    acceptDepositAgreement?: boolean
 }
 
 const DepositLicenseForm = () => (
@@ -66,9 +66,9 @@ const DepositLicenseForm = () => (
         </div>
 
         <div className="row form-group input-element">
-            <Field name="acceptLicenseAgreement"
+            <Field name="acceptDepositAgreement"
                    component={Checkbox}>
-                Yes, I accept and understand the terms of the License agreement<Mandatory/>
+                Yes, I accept and understand the terms of the Deposit agreement<Mandatory/>
             </Field>
         </div>
     </>

--- a/src/main/typescript/lib/metadata/License.ts
+++ b/src/main/typescript/lib/metadata/License.ts
@@ -19,7 +19,7 @@ import { emptyString } from "./misc"
 export const emptyLicense = emptyString
 
 export const dansLicense: DropdownListEntry = {
-    key: "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSlicenceagreementUK5.3DEF.pdf",
+    key: "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSlicenceagreementUK5.3DEF.pdf",//TODO DepositAgreement
     value: "DANS LICENSE",
     displayValue: "DANS LICENSE",
 }

--- a/src/main/typescript/lib/metadata/Metadata.ts
+++ b/src/main/typescript/lib/metadata/Metadata.ts
@@ -179,7 +179,7 @@ export const metadataConverter: (input: any, dropDowns: DropdownLists) => Deposi
         privacySensitiveDataPresent: privacySensitiveDataPresent,
 
         // deposit agreement
-        acceptLicenseAgreement: input.acceptLicenseAgreement || false,
+        acceptDepositAgreement: input.acceptDepositAgreement || false,
     }
 }
 
@@ -276,6 +276,6 @@ export const metadataDeconverter: (data: DepositFormMetadata, dropDowns: Dropdow
         privacySensitiveDataPresent: data.privacySensitiveDataPresent && privacySensitiveDataDeconverter(data.privacySensitiveDataPresent),
 
         // deposit license
-        acceptLicenseAgreement: data.acceptLicenseAgreement || undefined,
+        acceptDepositAgreement: data.acceptDepositAgreement || undefined,
     })
 }

--- a/src/test/typescript/mockserver/metadata.ts
+++ b/src/test/typescript/mockserver/metadata.ts
@@ -83,7 +83,7 @@ export interface Metadata {
     privacySensitiveDataPresent?: PrivacySensitiveDataValues
 
     // Deposit License
-    acceptLicenseAgreement?: boolean
+    acceptDepositAgreement?: boolean
 }
 
 interface SchemedValue<Scheme = string, Value = string> {
@@ -591,7 +591,7 @@ export const allfields: Metadata = {
         "Suspendisse ornare quis nunc sit amet tristique. Nam sed libero mauris. Duis scelerisque tortor non purus " +
         "porttitor interdum.",
     privacySensitiveDataPresent: PrivacySensitiveDataValues.NO,
-    acceptLicenseAgreement: true,
+    acceptDepositAgreement: true,
 }
 
 export const mandatoryOnly: Metadata = {
@@ -648,7 +648,7 @@ export const mandatoryOnly: Metadata = {
     },
     license: "http://creativecommons.org/publicdomain/zero/1.0",
     privacySensitiveDataPresent: PrivacySensitiveDataValues.YES,
-    // acceptLicenseAgreement: false, // if not set, this value is false by default
+    // acceptDepositAgreement: false, // if not set, this value is false by default
 }
 
 export const newMetadata: () => Metadata = () => ({})

--- a/src/test/typescript/mockserver/postman-calls.json
+++ b/src/test/typescript/mockserver/postman-calls.json
@@ -121,7 +121,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"doi\": \"doi:10.17632/DANS.6wg5xccnjd.2\",\n    \"languageOfDescription\": \"English\",\n    \"titles\": [\n    \t\"title1\"\n\t],\n    \"descriptions\": [\n        \"description1\",\n        \"description2\"\n    ],\n    \"creators\": [\n        {\n            \"initials\": \"A.S.\",\n            \"surname\": \"Terix\"\n        }\n    ],\n    \"dateCreated\": \"2018-03-19\",\n    \"audiences\": [\n        \"audience1\",\n        \"audience2\"\n    ],\n    \"accessRights\": {\n        \"category\": \"restricted_group\",\n        \"group\": \"archaeology\"\n    },\n    \"license\": \"CC-BY-NC-SA\",\n    \"extraClarinMetadataPresent\": true,\n    \"privacySensitiveDataPresent\": \"yes\",\n    \"acceptLicenseAgreement\": true\n}"
+					"raw": "{\n    \"doi\": \"doi:10.17632/DANS.6wg5xccnjd.2\",\n    \"languageOfDescription\": \"English\",\n    \"titles\": [\n    \t\"title1\"\n\t],\n    \"descriptions\": [\n        \"description1\",\n        \"description2\"\n    ],\n    \"creators\": [\n        {\n            \"initials\": \"A.S.\",\n            \"surname\": \"Terix\"\n        }\n    ],\n    \"dateCreated\": \"2018-03-19\",\n    \"audiences\": [\n        \"audience1\",\n        \"audience2\"\n    ],\n    \"accessRights\": {\n        \"category\": \"restricted_group\",\n        \"group\": \"archaeology\"\n    },\n    \"license\": \"CC-BY-NC-SA\",\n    \"extraClarinMetadataPresent\": true,\n    \"privacySensitiveDataPresent\": \"yes\",\n    \"acceptDepositAgreement\": true\n}"
 				},
 				"url": {
 					"raw": "http://localhost:3004/deposit/93674123-1699-49c5-af91-ed31db19adc9/metadata",


### PR DESCRIPTION
Fixes EASY-1820 rename: acceptLicenseAgreement --> acceptDepositAgreement

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

See related PR

#### Related pull requests on github
* [ ] merge / deploy together with https://github.com/DANS-KNAW/easy-deposit-api/pull/94
