### PR TITLE
EASY-1848: file POST expects 201 instead of 200

### DIFF
--- a/src/main/typescript/components/form/parts/fileUpload/upload/FileLoader.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/upload/FileLoader.tsx
@@ -135,7 +135,7 @@ class FileLoader<Response> extends Component<FileLoaderProps<Response>, FileLoad
     }
 
     handleResponse: (file: File, request: XMLHttpRequest) => Partial<FileLoaderState> = (file, request) => {
-        if (request.status == 200) {
+        if (request.status == 201) {
             this.props.onUploadFinished && this.props.onUploadFinished(file)
             return { uploadStatus: UploadStatus.DONE }
         }

--- a/src/test/typescript/mockserver/server.ts
+++ b/src/test/typescript/mockserver/server.ts
@@ -236,9 +236,9 @@ app.post("/deposit/:id/file/:dir_path*?", async (req: Request, res: Response) =>
 
         const newFiles = await Promise.all(promises)
 
-        res.status(200)
+        res.status(201)
         res.send(`Files uploaded: [${newFiles.join(", ")}]!`)
-        console.log("  200")
+        console.log("  201")
     }
     catch (err) {
         res.status(500).send(err)


### PR DESCRIPTION
Fixes EASY-1848

#### When applied it will
* change the expected `200` response to a `201`, as is specified by the [API](https://dans-knaw.github.io/easy-deposit-api/api.html#/directory/post_deposit__id__file__dir_path_)

@DANS-KNAW/easy for review