### PR TITLE
EASY-1850: make sure every <button> has a type parameter

### DIFF
--- a/src/main/typescript/components/Header.tsx
+++ b/src/main/typescript/components/Header.tsx
@@ -45,8 +45,8 @@ interface NavBarButtonProps {
 }
 
 const NavBarButton = ({ dataTarget }: NavBarButtonProps) => (
-    <button className="navbar-toggler"
-            type="button"
+    <button type="button"
+            className="navbar-toggler"
             data-toggle="collapse"
             data-target={`#${dataTarget}`}
             aria-controls={dataTarget}

--- a/src/main/typescript/components/form/parts/fileUpload/overview/FilesTableRow.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/overview/FilesTableRow.tsx
@@ -28,7 +28,8 @@ const FilesTableRow = ({ fileInfo: {fullpath, sha1sum}, deleting, deleteFile, as
     const isDeleting = deleting && deleting.deleting
 
     const deleteButton =
-        <button key="delete"
+        <button type="button"
+                key="delete"
                 className="close icon"
                 style={{ float: "unset" }}
                 disabled={isDeleting}

--- a/src/main/typescript/components/login/LoginCard.tsx
+++ b/src/main/typescript/components/login/LoginCard.tsx
@@ -32,8 +32,8 @@ const LoginCard: SFC<LoginCardProps> = ({ children, authenticating, errorMessage
             </div>
             <div className="card-body pl-0 pr-0 pb-0 ml-0 mr-0">
                 {children}
-                <button className="btn btn-dark ml-3 margin-top-bottom"
-                        type="submit"
+                <button type="submit"
+                        className="btn btn-dark ml-3 margin-top-bottom"
                         disabled={authenticating}>Login</button>
             </div>
             {errorMessage && <span>{errorMessage}<br/></span>}

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -38,7 +38,8 @@ const DepositTableRow = ({ deposit, deleting, deleteDeposit, editable, enterDepo
     const title = <Enterable title={deposit.title}/>
     const isDeleting = deleting && deleting.deleting
     const deleteButton = editable &&
-        <button key="delete"
+        <button type="button"
+                key="delete"
                 className="close icon"
                 disabled={isDeleting}
                 onClick={deleteDeposit}>

--- a/src/main/typescript/components/overview/NewDepositButton.tsx
+++ b/src/main/typescript/components/overview/NewDepositButton.tsx
@@ -35,7 +35,8 @@ class NewDepositButton extends Component<NewDepositButtonProps> {
 
     render() {
         return (
-            <button className="btn btn-dark margin-top-bottom"
+            <button type="button"
+                    className="btn btn-dark margin-top-bottom"
                     disabled={this.props.creatingNew}
                     title="Create new deposit..."
                     onClick={this.createNewDeposit}>{this.props.children}</button>


### PR DESCRIPTION
Fixes EASY-1850

#### When applied it will
* add a `type` parameter to every `<button>`
* make sure that every `<button>` has a `type` parameter listed first (just to be consistent and to have an easy search)

@DANS-KNAW/easy for review