### PR TITLE
EASY-1854: properly deal with 401 responses in login

### DIFF
--- a/src/main/typescript/actions/authenticationActions.ts
+++ b/src/main/typescript/actions/authenticationActions.ts
@@ -100,8 +100,14 @@ export const authenticate: (userName: string, password: string) => ComplexThunkA
 export const signout: () => ThunkAction<PromiseAction<void>> = () => (dispatch, getState) => dispatch({
     type: AuthenticationConstants.AUTH_LOGOUT,
     async payload() {
-        await axios.post(logoutUrl(getState()))
-        LocalStorage.setLogout()
+        try {
+            await axios.post(logoutUrl(getState()))
+            LocalStorage.setLogout()
+        }
+        catch (logoutResponse) {
+            LocalStorage.setLogout()
+            throw logoutResponse
+        }
     },
 })
 

--- a/src/main/typescript/actions/authenticationActions.ts
+++ b/src/main/typescript/actions/authenticationActions.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as H from "history"
 import { ComplexThunkAction, PromiseAction, ThunkAction } from "../lib/redux"
 import { AuthenticationConstants } from "../constants/authenticationConstants"
 import axios from "axios"
@@ -30,14 +29,9 @@ const authenticateFulfilled = ({
     type: AuthenticationConstants.AUTH_LOGIN_FULFILLED,
 })
 
-const authenticateRejected = (location: H.Location) => (response: any) => ({
+const authenticateRejected = (message: string) => ({
     type: AuthenticationConstants.AUTH_LOGIN_REJECTED,
-    payload: response.response
-        ? { response: response.response } // when received error code (401, etc.)
-        : { message: response.message }, // when network error occurs (no internet?) or user data could not be fetched
-    meta: {
-        location: location
-    }
+    payload: message, // when network error occurs (no internet?) or user data could not be fetched
 })
 
 const userPending = ({
@@ -52,7 +46,7 @@ const userFulfilled = (data: any) => ({
     },
 })
 
-export const authenticate: (location: H.Location, userName: string, password: string) => ComplexThunkAction = (location, userName, password) => async (dispatch, getState) => {
+export const authenticate: (userName: string, password: string) => ComplexThunkAction = (userName, password) => async (dispatch, getState) => {
     /*
      * dispatch AUTH_LOGIN_PENDING
      * call server with 'auth/login'
@@ -73,7 +67,7 @@ export const authenticate: (location: H.Location, userName: string, password: st
     dispatch(authenticatePending)
 
     try {
-        const loginResponse = await axios.post(loginUrl(getState()), {}, {
+        await axios.post(loginUrl(getState()), {}, {
             auth: {
                 password: password,
                 username: userName,
@@ -93,13 +87,13 @@ export const authenticate: (location: H.Location, userName: string, password: st
         catch (userResponse) {
             LocalStorage.setLogout()
 
-            dispatch(authenticateRejected(location)({ message: `not able to fetch user details: ${userResponse.response.status} - ${userResponse.response.statusText}` }))
+            dispatch(authenticateRejected(`not able to fetch user details: ${userResponse.response.data}`))
         }
     }
     catch (loginResponse) {
         LocalStorage.setLogout()
 
-        dispatch(authenticateRejected(location)(loginResponse))
+        dispatch(authenticateRejected(`not able to login: ${loginResponse.response.data}`))
     }
 }
 

--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -48,13 +48,13 @@ import { fetchFiles } from "../../actions/fileOverviewActions"
 import { formValidate } from "./Validation"
 import { inDevelopmentMode } from "../../lib/config"
 
-interface FetchMetadataErrorProps {
+interface FetchDataErrorProps {
     fetchError?: string
 
     reload: () => any
 }
 
-const FetchMetadataError = ({ fetchError, reload }: FetchMetadataErrorProps) => (
+const FetchDataError = ({ fetchError, reload }: FetchDataErrorProps) => (
     fetchError
         ? <ReloadAlert key="fetchMetadataError" reload={reload}>
             An error occurred: {fetchError}. Cannot load metadata from the server.
@@ -182,7 +182,9 @@ class DepositForm extends Component<DepositFormProps> {
                 <Prompt when={this.shouldBlockNavigation()}
                         message={DepositForm.leaveMessage}/>
 
-                <FetchMetadataError fetchError={fetchedMetadataError} reload={this.fetchMetadata}/>
+                <FetchDataError fetchError={fetchedFilesError} reload={this.fetchFiles}/>
+                <FetchDataError fetchError={fetchedMetadataError} reload={this.fetchMetadata}/>
+
                 <form>
                     <Card title="Upload your data" defaultOpened>
                         <Loaded loading={fetchingFiles} loaded={fetchedFiles} error={fetchedFilesError}>

--- a/src/main/typescript/components/form/parts/fileUpload/overview/FilesOverview.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/overview/FilesOverview.tsx
@@ -27,6 +27,7 @@ import { askConfirmation, cancelDeleteFile, deleteFile, fetchFiles } from "../..
 import { Action } from "redux"
 import { uploadFileUrl } from "../../../../../selectors/serverRoutes"
 import EmptyFileTableRow from "./EmptyFileTableRow"
+import { CloseableWarning } from "../../../../Errors"
 
 interface FilesOverviewInputProps {
     depositId: DepositId
@@ -49,6 +50,7 @@ class FilesOverview extends Component<FilesOverviewProps & FilesOverviewInputPro
         return (
             <>
                 {loading && <p>loading files ...</p>}
+                {this.renderDeleteError()}
                 {loaded && this.renderTable()}
             </>
         )
@@ -65,6 +67,21 @@ class FilesOverview extends Component<FilesOverviewProps & FilesOverviewInputPro
     cancelDeleteFile = (filepath: string) => (e: React.MouseEvent<HTMLButtonElement>) => {
         e.stopPropagation()
         this.props.cancelDeleteFile(filepath)
+    }
+
+    private renderDeleteError() {
+        const { files: { deleting } } = this.props
+
+        return Object.keys(deleting)
+            .map(fileId => {
+                const { deleteError } = deleting[fileId]
+
+                if (deleteError) {
+                    const errorText = `Cannot delete file '${fileId}'. An error occurred: ${deleteError}.`
+
+                    return <CloseableWarning key={`deleteError.${fileId}`}>{errorText}</CloseableWarning>
+                }
+            })
     }
 
     private renderTable() {

--- a/src/main/typescript/components/login/EasyLogin.tsx
+++ b/src/main/typescript/components/login/EasyLogin.tsx
@@ -15,6 +15,8 @@
  */
 import * as React from "react"
 import { Component, ComponentType } from "react"
+import * as H from "history"
+import { RouteComponentProps, withRouter } from "react-router"
 import { ComplexThunkAction } from "../../lib/redux"
 import { authenticate } from "../../actions/authenticationActions"
 import { Field, InjectedFormProps, reduxForm } from "redux-form"
@@ -50,14 +52,14 @@ interface EasyLoginProps {
     authenticating: boolean
     errorMessage?: string
 
-    authenticate: (username: string, password: string) => ComplexThunkAction
+    authenticate: (location: H.Location, username: string, password: string) => ComplexThunkAction
 }
 
-type AllEasyLoginProps = EasyLoginProps & InjectedFormProps<EasyLoginData>
+type AllEasyLoginProps = EasyLoginProps & InjectedFormProps<EasyLoginData> & RouteComponentProps<{}>
 
 class EasyLogin extends Component<AllEasyLoginProps> {
     callAuthenticate = (formValues: EasyLoginData) => {
-        this.props.authenticate(formValues.username, formValues.password)
+        this.props.authenticate(this.props.location, formValues.username, formValues.password)
     }
 
     render() {
@@ -98,6 +100,7 @@ const mapEasyLoginStateToProps = (state: AppState) => ({
 })
 
 const composedEasyLoginHOC = compose(
+    withRouter,
     connect(mapEasyLoginStateToProps, { authenticate }),
     reduxForm<EasyLoginData>({
         form: loginFormName,

--- a/src/main/typescript/components/login/EasyLogin.tsx
+++ b/src/main/typescript/components/login/EasyLogin.tsx
@@ -63,7 +63,6 @@ class EasyLogin extends Component<AllEasyLoginProps> {
     render() {
         const { authenticating, errorMessage, handleSubmit } = this.props
 
-        // TODO add form validation
         return (
             <LoginCard headerName="EASY account">
                 <form>
@@ -100,7 +99,10 @@ const mapEasyLoginStateToProps = (state: AppState) => ({
 
 const composedEasyLoginHOC = compose(
     connect(mapEasyLoginStateToProps, { authenticate }),
-    reduxForm<EasyLoginData>({ form: "easyLogin" }),
+    reduxForm<EasyLoginData>({
+        form: loginFormName,
+        validate: formValidate,
+    }),
 )
 
 export default composedEasyLoginHOC(EasyLogin)

--- a/src/main/typescript/components/login/EasyLogin.tsx
+++ b/src/main/typescript/components/login/EasyLogin.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import * as React from "react"
-import { Component } from "react"
-import { ComplexThunkAction, PromiseAction, ThunkAction } from "../../lib/redux"
+import { Component, ComponentType } from "react"
+import { ComplexThunkAction } from "../../lib/redux"
 import { authenticate } from "../../actions/authenticationActions"
 import { Field, InjectedFormProps, reduxForm } from "redux-form"
 import { AppState } from "../../model/AppState"
@@ -23,11 +23,28 @@ import { compose } from "redux"
 import { connect } from "react-redux"
 import TextField from "../../lib/formComponents/TextField"
 import LoginCard from "./LoginCard"
+import { formValidate } from "./Validation"
+import { EasyLoginData } from "./index"
+import { loginFormName } from "../../constants/authenticationConstants"
+import { FieldProps } from "../../lib/formComponents/ReduxFormUtils"
 
-interface EasyLoginData {
-    username: string
-    password: string
+const asField = (InnerComponent: ComponentType<any>) => (props: FieldProps) => {
+    const { label, input: { name }, meta: { error, submitFailed } } = props
+    const hasError = error && submitFailed
+
+    return (
+        <div className="row ml-0 mr-0 mb-1 form-group">
+            <label htmlFor={name}
+                   className="col-12 col-md-4 col-lg-3 col-form-label">{label}</label>
+            <div className="col-12 col-md-8 col-lg-9">
+                <InnerComponent className={hasError ? "is-invalid" : ""} id={name} {...props} />
+                {hasError && <span className="invalid-feedback">{error}</span>}
+            </div>
+        </div>
+    )
 }
+
+const LoginTextField = asField(TextField)
 
 interface EasyLoginProps {
     authenticating: boolean
@@ -44,40 +61,33 @@ class EasyLogin extends Component<AllEasyLoginProps> {
     }
 
     render() {
-        const {authenticating, errorMessage, handleSubmit} = this.props
+        const { authenticating, errorMessage, handleSubmit } = this.props
 
         // TODO add form validation
         return (
-            <LoginCard authenticating={authenticating}
-                       errorMessage={errorMessage}
-                       onSubmit={handleSubmit(this.callAuthenticate)}
-                       header={() => <>EASY account</>}>
-                <div className="container pl-0 pr-0 pb-0 ml-0 mr-0">
-                    <div className="row ml-0 mr-0 mb-1 form-group">
-                        <label htmlFor="username"
-                               className="col-12 col-md-5 col-lg-4 col-form-label">Username</label>
-                        <div className="col-12 col-md-7 col-lg-8">
-                            <Field name="username"
-                                   label="Username"
-                                   id="username"
-                                   autoFocus
-                                   required
-                                   component={TextField}/>
-                        </div>
-                    </div>
-                    <div className="form-group row ml-0 mr-0 mb-0">
-                        <label htmlFor="password"
-                               className="col-12 col-md-5 col-lg-4 col-form-label">Password</label>
-                        <div className="col-12 col-md-7 col-lg-8">
-                            <Field name="password"
-                                   label="Password"
-                                   id="password"
-                                   type="password"
-                                   required
-                                   component={TextField}/>
-                        </div>
-                    </div>
-                </div>
+            <LoginCard headerName="EASY account">
+                <form>
+                    <Field name="username"
+                           label="Username"
+                           autoFocus
+                           required
+                           component={LoginTextField}/>
+
+                    <Field name="password"
+                           label="Password"
+                           type="password"
+                           required
+                           component={LoginTextField}/>
+
+                    {errorMessage && <span>{errorMessage}<br/></span>}
+
+                    <button type="button"
+                            className="btn btn-dark ml-3 margin-top-bottom"
+                            onClick={handleSubmit(this.callAuthenticate)}
+                            disabled={authenticating}>
+                        Login
+                    </button>
+                </form>
             </LoginCard>
         )
     }

--- a/src/main/typescript/components/login/EasyLogin.tsx
+++ b/src/main/typescript/components/login/EasyLogin.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react"
-import { Component, ComponentType } from "react"
+import { Component, ComponentType, FC, HTMLAttributes } from "react"
 import * as H from "history"
 import { RouteComponentProps, withRouter } from "react-router"
 import { ComplexThunkAction } from "../../lib/redux"
@@ -29,6 +29,7 @@ import { formValidate } from "./Validation"
 import { EasyLoginData } from "./index"
 import { loginFormName } from "../../constants/authenticationConstants"
 import { FieldProps } from "../../lib/formComponents/ReduxFormUtils"
+import { Alert } from "../Errors"
 
 const asField = (InnerComponent: ComponentType<any>) => (props: FieldProps) => {
     const { label, input: { name }, meta: { error, submitFailed } } = props
@@ -47,6 +48,10 @@ const asField = (InnerComponent: ComponentType<any>) => (props: FieldProps) => {
 }
 
 const LoginTextField = asField(TextField)
+
+const LoginError: FC<HTMLAttributes<HTMLDivElement>> = ({ children, ...rest }) => (
+    <div {...rest}><Alert>{children}</Alert></div>
+)
 
 interface EasyLoginProps {
     authenticating: boolean
@@ -80,7 +85,7 @@ class EasyLogin extends Component<AllEasyLoginProps> {
                            required
                            component={LoginTextField}/>
 
-                    {errorMessage && <span>{errorMessage}<br/></span>}
+                    {errorMessage && <LoginError className="mt-3 ml-3 mr-3">{errorMessage}</LoginError>}
 
                     <button type="button"
                             className="btn btn-dark ml-3 margin-top-bottom"

--- a/src/main/typescript/components/login/EasyLogin.tsx
+++ b/src/main/typescript/components/login/EasyLogin.tsx
@@ -15,8 +15,6 @@
  */
 import * as React from "react"
 import { Component, ComponentType, FC, HTMLAttributes } from "react"
-import * as H from "history"
-import { RouteComponentProps, withRouter } from "react-router"
 import { ComplexThunkAction } from "../../lib/redux"
 import { authenticate } from "../../actions/authenticationActions"
 import { Field, InjectedFormProps, reduxForm } from "redux-form"
@@ -57,14 +55,14 @@ interface EasyLoginProps {
     authenticating: boolean
     errorMessage?: string
 
-    authenticate: (location: H.Location, username: string, password: string) => ComplexThunkAction
+    authenticate: (username: string, password: string) => ComplexThunkAction
 }
 
-type AllEasyLoginProps = EasyLoginProps & InjectedFormProps<EasyLoginData> & RouteComponentProps<{}>
+type AllEasyLoginProps = EasyLoginProps & InjectedFormProps<EasyLoginData>
 
 class EasyLogin extends Component<AllEasyLoginProps> {
     callAuthenticate = (formValues: EasyLoginData) => {
-        this.props.authenticate(this.props.location, formValues.username, formValues.password)
+        this.props.authenticate(formValues.username, formValues.password)
     }
 
     render() {
@@ -105,7 +103,6 @@ const mapEasyLoginStateToProps = (state: AppState) => ({
 })
 
 const composedEasyLoginHOC = compose(
-    withRouter,
     connect(mapEasyLoginStateToProps, { authenticate }),
     reduxForm<EasyLoginData>({
         form: loginFormName,

--- a/src/main/typescript/components/login/Validation.ts
+++ b/src/main/typescript/components/login/Validation.ts
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export enum AuthenticationConstants {
-    AUTH_LOGIN = "AUTH_LOGIN",
-    AUTH_LOGIN_PENDING = "AUTH_LOGIN_PENDING",
-    AUTH_LOGIN_REJECTED ="AUTH_LOGIN_REJECTED",
-    AUTH_LOGIN_FULFILLED = "AUTH_LOGIN_FULFILLED",
+import { FormErrors } from "redux-form"
+import { EasyLoginData } from "./index"
+import { mandatoryFieldValidator } from "../form/Validation"
 
-    AUTH_LOGOUT = "AUTH_LOGOUT",
-    AUTH_LOGOUT_FULFILLED = "AUTH_LOGOUT_FULFILLED",
+export const formValidate: (values: EasyLoginData) => FormErrors<EasyLoginData> = values => {
+    const errors: FormErrors<EasyLoginData> = {}
+
+    errors.username = mandatoryFieldValidator(values.username, "username")
+    errors.password = mandatoryFieldValidator(values.password, "password")
+
+    return errors
 }
-
-export const loginFormName = "easyLogin"

--- a/src/main/typescript/components/login/index.ts
+++ b/src/main/typescript/components/login/index.ts
@@ -13,22 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react"
-import { ComponentType, FC } from "react"
-
-interface LoginCardProps {
-    headerName: string
+export interface EasyLoginData {
+    username: string
+    password: string
 }
-
-const LoginCard: FC<LoginCardProps> = ({ children, headerName }) => (
-    <div className="card pl-0 pr-0 mb-4 mb-md-0 col col-12 col-md-5">
-        <div className="card-header bg-primary text-white">
-            {headerName}
-        </div>
-        <div className="card-body pl-0 pr-0 pb-0 ml-0 mr-0">
-            {children}
-        </div>
-    </div>
-)
-
-export default LoginCard

--- a/src/main/typescript/components/overview/DepositOverview.tsx
+++ b/src/main/typescript/components/overview/DepositOverview.tsx
@@ -96,7 +96,7 @@ class DepositOverview extends Component<DepositOverviewProps> {
                         ? `Cannot delete deposit '${deposit.title}'. An error occurred: ${deleteError}.`
                         : `Cannot delete a deposit. An error occurred: ${deleteError}.`
 
-                    return <CloseableWarning>{errorText}</CloseableWarning>
+                    return <CloseableWarning key={`deleteError.${depositId}`}>{errorText}</CloseableWarning>
                 }
             })
     }

--- a/src/main/typescript/constants/authenticationConstants.ts
+++ b/src/main/typescript/constants/authenticationConstants.ts
@@ -21,6 +21,7 @@ export enum AuthenticationConstants {
 
     AUTH_LOGOUT = "AUTH_LOGOUT",
     AUTH_LOGOUT_FULFILLED = "AUTH_LOGOUT_FULFILLED",
+    AUTH_LOGOUT_REJECTED = "AUTH_LOGOUT_REJECTED",
 }
 
 export const loginFormName = "easyLogin"

--- a/src/main/typescript/middleware/rejectedRequestMiddleware.ts
+++ b/src/main/typescript/middleware/rejectedRequestMiddleware.ts
@@ -14,26 +14,14 @@
  * limitations under the License.
  */
 import { Dispatch, Middleware } from "redux"
-import LocalStorage from "../lib/LocalStorage"
-import { AuthenticationConstants } from "../constants/authenticationConstants"
 
-const newRejectedMiddleware: Middleware = ({ dispatch }) => (next: Dispatch) => action => {
+const newRejectedMiddleware: Middleware = () => (next: Dispatch) => action => {
     if (action.type && action.type.endsWith("_REJECTED") && action.payload) {
-        const { payload, meta } = action
+        const { payload } = action
 
-        if (payload.response && payload.response.status === 401 &&
-            // discard any FETCH_XXX_REJECTED actions with 401 status, except if we're on the login page
-            meta && meta.location && meta.location.pathname !== "/login") {
-            LocalStorage.setLogout()
-            dispatch({
-                type: AuthenticationConstants.AUTH_LOGIN_REJECTED,
-            })
-            next(action)
-        }
-        else if (!!payload.response || !!payload.message) {
-            const response = payload.response
-            const errorMessage = response
-                ? response.data
+        if (!!payload.response || !!payload.message) {
+            const errorMessage = payload.response
+                ? payload.response.data
                 : payload.message
 
             next({ ...action, payload: errorMessage })

--- a/src/main/typescript/model/FileInfo.ts
+++ b/src/main/typescript/model/FileInfo.ts
@@ -41,6 +41,8 @@ export const emptyDelete: DeleteState = ({
     deleted: false,
 })
 
+export const emptyDeleteStates: DeletingStates = {}
+
 export interface NewFileState {
     creating: boolean
     createError?: string

--- a/src/main/typescript/reducers/authenticationReducer.ts
+++ b/src/main/typescript/reducers/authenticationReducer.ts
@@ -23,12 +23,15 @@ export const authenticationReducer: Reducer<Authentication> = (state = empty, ac
             return { ...state, isAuthenticated: true, isAuthenticating: false, authenticationError: undefined }
         }
         case AuthenticationConstants.AUTH_LOGIN_PENDING: {
-            return { ...state, isAuthenticated: false, isAuthenticating: true }
+            return { ...state, isAuthenticated: false, isAuthenticating: true, authenticationError: undefined }
         }
         case AuthenticationConstants.AUTH_LOGIN_REJECTED: {
             return { ...state, isAuthenticated: false, isAuthenticating: false, authenticationError: action.payload }
         }
         case AuthenticationConstants.AUTH_LOGOUT_FULFILLED: {
+            return { ...state, isAuthenticated: false, isAuthenticating: false, authenticationError: undefined }
+        }
+        case AuthenticationConstants.AUTH_LOGOUT_REJECTED: {
             return { ...state, isAuthenticated: false, isAuthenticating: false, authenticationError: undefined }
         }
         default:

--- a/src/main/typescript/reducers/fileOverviewReducer.ts
+++ b/src/main/typescript/reducers/fileOverviewReducer.ts
@@ -13,8 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FileOverviewState, empty, DeleteState, emptyDelete } from "../model/FileInfo"
 import { Reducer } from "redux"
+import {
+    DeleteState,
+    DeletingStates,
+    empty,
+    emptyDelete,
+    emptyDeleteStates,
+    FileOverviewState,
+} from "../model/FileInfo"
 import { FileOverviewConstants } from "../constants/fileOverviewConstants"
 
 export const fileOverviewReducer: Reducer<FileOverviewState> = (state = empty, action) => {
@@ -52,9 +59,14 @@ export const fileOverviewReducer: Reducer<FileOverviewState> = (state = empty, a
         case FileOverviewConstants.DELETE_FILE_FULFILLED: {
             const { meta: { filePath } } = action
 
-            const newDeleteState: DeleteState = { deleting: false, deleted: true }
+            const newDeleteState = Object.keys(state.deleting)
+                .filter(value => value !== filePath)
+                .reduce((obj: DeletingStates) => {
+                    obj[filePath] = state.deleting[filePath]
+                    return obj
+                }, emptyDeleteStates)
 
-            return { ...state, deleting: { ...state.deleting, [filePath]: newDeleteState }}
+            return { ...state, deleting: newDeleteState }
         }
         case FileOverviewConstants.DELETE_FILE_CONFIRMATION: {
             const { meta: { filePath } } = action
@@ -69,11 +81,14 @@ export const fileOverviewReducer: Reducer<FileOverviewState> = (state = empty, a
         case FileOverviewConstants.DELETE_FILE_CANCELLED: {
             const { meta: { filePath } } = action
 
-            const deleteState: DeleteState = state.deleting[filePath]
-            const newDeleteState: DeleteState = deleteState
-                ? { ...deleteState, deleting: false}
-                : { ...emptyDelete, deleting: false}
-            return { ...state, deleting: { ...state.deleting, [filePath]: newDeleteState}}
+            const newDeleteState = Object.keys(state.deleting)
+                .filter(value => value !== filePath)
+                .reduce((obj: DeletingStates) => {
+                    obj[filePath] = state.deleting[filePath]
+                    return obj
+                }, emptyDeleteStates)
+
+            return { ...state, deleting: newDeleteState }
         }
         default:
             return state

--- a/src/test/typescript/mockserver/server.ts
+++ b/src/test/typescript/mockserver/server.ts
@@ -47,11 +47,23 @@ app.get("/deposit", (req: Request, res: Response) => {
     res.json(listDeposits())
     console.log("  200")
 })
+app.get("/deposit401", (req: Request, res: Response) => {
+    console.log("GET /deposit")
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
+})
 app.post("/deposit", (req: Request, res: Response) => {
     console.log("POST /deposit")
     res.status(201)
     res.json(createDeposit())
     console.log("  201")
+})
+app.post("/deposit401", (req: Request, res: Response) => {
+    console.log("POST /deposit")
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
 })
 
 app.get("/deposit/:id", (req: Request, res: Response) => {
@@ -59,6 +71,12 @@ app.get("/deposit/:id", (req: Request, res: Response) => {
     res.status(200)
     res.json(getDeposit(req.params.id))
     console.log("  200")
+})
+app.get("/deposit401/:id", (req: Request, res: Response) => {
+    console.log(`GET /deposit/${req.params.id}`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
 })
 app.delete("/deposit/:id", (req: Request, res: Response) => {
     console.log(`DELETE /deposit/${req.params.id}`)
@@ -72,6 +90,12 @@ app.delete("/deposit/:id", (req: Request, res: Response) => {
         res.send("Not found.")
         console.log("  404")
     }
+})
+app.delete("/deposit401/:id", (req: Request, res: Response) => {
+    console.log(`DELETE /deposit/${req.params.id}`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
 })
 
 app.get("/deposit/:id/metadata", (req: Request, res: Response) => {
@@ -95,6 +119,12 @@ app.get("/deposit/:id/metadata", (req: Request, res: Response) => {
         console.log("  404")
     }
 })
+app.get("/deposit401/:id/metadata", (req: Request, res: Response) => {
+    console.log(`GET /deposit/${req.params.id}/metadata`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
+})
 app.put("/deposit/:id/metadata", (req: Request, res: Response) => {
     console.log(`PUT /deposit/${req.params.id}/metadata`)
     if (hasMetadata(req.params.id)) {
@@ -108,6 +138,12 @@ app.put("/deposit/:id/metadata", (req: Request, res: Response) => {
         res.send("Not found. The client may derive from this response that the containing deposit does not exist, either.")
         console.log("  404")
     }
+})
+app.put("/deposit401/:id/metadata", (req: Request, res: Response) => {
+    console.log(`PUT /deposit/${req.params.id}/metadata`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
 })
 
 app.get("/deposit/:id/doi", (req: Request, res: Response) => {
@@ -129,6 +165,12 @@ app.get("/deposit/:id/doi", (req: Request, res: Response) => {
         res.send("Not found. The client may derive from this response that the containing deposit does not exist, either.")
     }
 })
+app.get("/deposit401/:id/doi", (req: Request, res: Response) => {
+    console.log(`GET /deposit/${req.params.id}/doi`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
+})
 
 app.get("/deposit/:id/state", (req: Request, res: Response) => {
     console.log(`GET /deposit/${req.params.id}/state`)
@@ -143,6 +185,12 @@ app.get("/deposit/:id/state", (req: Request, res: Response) => {
         res.send("Not found. The client may derive from this response that the containing deposit does not exist, either.")
         console.log("  404")
     }
+})
+app.get("/deposit401/:id/state", (req: Request, res: Response) => {
+    console.log(`GET /deposit/${req.params.id}/state`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
 })
 app.put("/deposit/:id/state", (req: Request, res: Response) => {
     console.log(`PUT /deposit/${req.params.id}/state`)
@@ -180,6 +228,12 @@ app.put("/deposit/:id/state", (req: Request, res: Response) => {
         console.log("  400")
     }
 })
+app.put("/deposit401/:id/state", (req: Request, res: Response) => {
+    console.log(`PUT /deposit/${req.params.id}/state`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
+})
 
 app.get("/deposit/:id/file/:dir_path*?", (req: Request, res: Response) => {
     const depositId = req.params.id
@@ -206,6 +260,15 @@ app.get("/deposit/:id/file/:dir_path*?", (req: Request, res: Response) => {
             console.log("  404")
         }
     }
+})
+app.get("/deposit401/:id/file/:dir_path*?", (req: Request, res: Response) => {
+    const dir_path = req.params.dir_path
+    const restPath = req.params[0]
+    const dirPath = dir_path && restPath ? dir_path + restPath : (dir_path || "")
+    console.log(`GET /deposit/${req.params.id}/file/${dirPath}`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
 })
 app.post("/deposit/:id/file/:dir_path*?", async (req: Request, res: Response) => {
     const depositId = req.params.id
@@ -245,6 +308,15 @@ app.post("/deposit/:id/file/:dir_path*?", async (req: Request, res: Response) =>
         console.log("  500")
     }
 })
+app.post("/deposit401/:id/file/:dir_path*?", (req: Request, res: Response) => {
+    const dir_path = req.params.dir_path
+    const restPath = req.params[0]
+    const dirPath = dir_path && restPath ? dir_path + restPath : (dir_path || "")
+    console.log(`POST /deposit/${req.params.id}/file/${dirPath}`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
+})
 app.put("/deposit/:id/file/:file_path", (req: Request, res: Response) => {
     console.log(`PUT /deposit/${req.params.id}/file${req.params.file_path ? `/${req.params.file_path}` : ""}`)
 
@@ -270,12 +342,27 @@ app.delete("/deposit/:id/file/:dir_path*?", (req: Request, res: Response) => {
         console.log("  404")
     }
 })
+app.delete("/deposit401/:id/file/:dir_path*?", (req: Request, res: Response) => {
+    const dir_path = req.params.dir_path
+    const restPath = req.params[0]
+    const dirPath = dir_path && restPath ? dir_path + restPath : (dir_path || "")
+    console.log(`DELETE /deposit/${req.params.id}/file/${dirPath}`)
+    res.status(401)
+    res.send("You are not authorized")
+    console.log("  401")
+})
 
 app.get("/user", (req: Request, res: Response) => {
     console.log("GET /user")
     res.status(200)
     res.json(getUser())
     console.log("  200")
+})
+app.get("/user401", (req: Request, res: Response) => {
+    console.log("GET /user")
+    res.status(401)
+    res.send("you are not authorized")
+    console.log("  401")
 })
 
 app.post("/auth/login", (req: Request, res: Response) => {

--- a/src/test/typescript/mockserver/server.ts
+++ b/src/test/typescript/mockserver/server.ts
@@ -272,20 +272,20 @@ app.delete("/deposit/:id/file/:dir_path*?", (req: Request, res: Response) => {
 })
 
 app.get("/user", (req: Request, res: Response) => {
-    console.log(`GET /user`)
+    console.log("GET /user")
     res.status(200)
     res.json(getUser())
     console.log("  200")
 })
 
 app.post("/auth/login", (req: Request, res: Response) => {
-    console.log(`POST /auth/login`)
+    console.log("POST /auth/login")
     res.status(204)
     res.send()
     console.log("  204")
 })
 app.post("/auth/login401", async (req: Request, res: Response) => {
-    console.log(`POST /auth/login`)
+    console.log("POST /auth/login")
 
     await new Promise(resolve => setTimeout(resolve, 3000))
 
@@ -294,14 +294,14 @@ app.post("/auth/login401", async (req: Request, res: Response) => {
     console.log("  401")
 })
 app.post("/auth/login500", (req: Request, res: Response) => {
-    console.log(`POST /auth/login`)
+    console.log("POST /auth/login")
     res.status(500)
     res.send("Internal Server Error")
     console.log("  500")
 })
 
 app.post("/auth/logout", (req: Request, res: Response) => {
-    console.log(("POST /auth/logout"))
+    console.log("POST /auth/logout")
     res.status(204)
     res.send()
     console.log("  204")

--- a/src/test/typescript/mockserver/server.ts
+++ b/src/test/typescript/mockserver/server.ts
@@ -284,10 +284,13 @@ app.post("/auth/login", (req: Request, res: Response) => {
     res.send()
     console.log("  204")
 })
-app.post("/auth/login401", (req: Request, res: Response) => {
+app.post("/auth/login401", async (req: Request, res: Response) => {
     console.log(`POST /auth/login`)
+
+    await new Promise(resolve => setTimeout(resolve, 3000))
+
     res.status(401)
-    res.send("Unauthorized")
+    res.send("A message identifying the reason for not being allowed to login")
     console.log("  401")
 })
 app.post("/auth/login403", (req: Request, res: Response) => {

--- a/src/test/typescript/mockserver/server.ts
+++ b/src/test/typescript/mockserver/server.ts
@@ -306,5 +306,11 @@ app.post("/auth/logout", (req: Request, res: Response) => {
     res.send()
     console.log("  204")
 })
+app.post("/auth/logout401", (req: Request, res: Response) => {
+    console.log("POST /auth/logout")
+    res.status(401)
+    res.send("you are not authorized")
+    console.log("  401")
+})
 
 app.listen(3004, () => console.log("Running on localhost:3004"))

--- a/src/test/typescript/mockserver/server.ts
+++ b/src/test/typescript/mockserver/server.ts
@@ -293,12 +293,6 @@ app.post("/auth/login401", async (req: Request, res: Response) => {
     res.send("A message identifying the reason for not being allowed to login")
     console.log("  401")
 })
-app.post("/auth/login403", (req: Request, res: Response) => {
-    console.log(`POST /auth/login`)
-    res.status(403)
-    res.send("Forbidden")
-    console.log("  403")
-})
 app.post("/auth/login500", (req: Request, res: Response) => {
     console.log(`POST /auth/login`)
     res.status(500)


### PR DESCRIPTION
Fixes EASY-1854

#### When applied it will
* fix some broken stuff with error handling on the login page (now it shows the error messages again and in a better way)
* add a number of servlet endpoints to test for error responses from the server
* add a number of forgotten error displays to the UI
* have a refactored login form
    * no more nested Bootstrap containers
    * the form is now inside the card (which is better for rendering) rather than the other way around
* fix logout error handling
* add validation to the login form

@DANS-KNAW/easy for review

* [x] awaits server side solution for this bug by @jo-pol --> see https://github.com/DANS-KNAW/easy-deposit-api/pull/110