### PR TITLE
EASY-1915: describe validation messages

### DIFF
--- a/doc/validation.md
+++ b/doc/validation.md
@@ -1,0 +1,126 @@
+Validation rules in `easy-deposit-ui`
+=====================================
+
+This document describes the various validation rules that are applied to the forms in `easy-deposit-ui`.
+The errors caught in the validation process are accumulated and presented to the user on screen.
+
+
+Login form
+----------
+
+* **username**
+  * mandatory field
+    * _error text:_ "no username was provided"
+* **password**
+  * mandatory field
+    * _error text:_ "no password was provided"
+
+
+Deposit form
+------------
+
+### Basic information form
+
+* **doi**
+  * mandatory field
+    * _error text:_ "no doi was provided"
+* **languageOfDescription**
+  * mandatory field
+    * _error text:_ "no language of description was provided"
+* **titles**
+  * mandatory field array
+    * _error text:_ "no titles were provided"
+* **description**
+  * mandatory field
+    * _error text:_ "no description was provided"
+* **contributors**
+  * mandatory field array
+    * _error text:_ "no contributors were provided"
+  * one creator minimum
+    * _error text:_ "at least one creator is required"
+  * every nonempty contributor must have either an organization or {initial, surname}
+    * _error text:_ "no organization given"
+    * _error text:_ "no initials given"
+    * _error text:_ "no surname given"
+  * no partially filled in identifiers
+    * _error text:_ "no scheme given"
+    * _error text:_ "no identifier given"
+* **dateCreated**
+  * mandatory field
+    * _error text:_ "no date created was provided"
+* **audiences**
+  * mandatory field array
+    * _error text:_ "no audiences were provided"
+* **alternativeIdentifiers**
+  * no partially filled in identifiers
+    * _error text:_ "no scheme given"
+    * _error text:_ "no identifier given"
+* **relatedIdentifiers**
+  * if it has one element, only validate if either `scheme` or `value` is filled in
+  * no partially filled in identifiers
+    * _error text:_ "no scheme given"
+    * _error text:_ "no identifier given"
+* **relations**
+  * if it has one element, only validate if either `title` or `url` is filled in
+  * only a qualifier is selected
+    * _error text:_ "no title given"
+    * _error text:_ "no url given"
+  * only a url and qualifier are given
+    * _error text:_ "no title given"
+  * only a valid URL is allowed
+    * _error text:_ "no valid url given"
+* **datesIso8601**
+  * only validate if multiple elements are provided
+  * mandatory value field
+    * _error text:_ "no date given"
+* **dates**
+  * only validate if multiple elements are provided
+  * mandatory value field
+    * _error text:_ "no date given"
+
+### License and access form
+
+* **rightsHolders**
+  * every nonempty contributor must have either an organization or {initial, surname}
+    * _error text:_ "no organization given"
+    * _error text:_ "no initials given"
+    * _error text:_ "no surname given"
+  * every nonempty contributor must have no partially filled in identifiers
+    * _error text:_ "no scheme given"
+    * _error text:_ "no identifier given"
+* **accessRights**
+  * mandatory radio button
+    * _error text:_ "no access right was chosen"
+* **license**
+  * mandatory radio button
+    * _error text:_ "no license was chosen"
+* **dateAvailable**
+  * `dateAvailable` must be earlier than `dateCreated`
+    * _error text:_ "'Date available' cannot be a date earlier than 'Date created'"
+
+### Temporal and spatial coverage form
+
+* **spatialPoints**
+  * all fields of an entry must be filled in
+    * _error text:_ "no scheme given"
+    * _error text:_ "no x coordinate given"
+    * _error text:_ "no y coordinate given"
+* **spatialBoxes**
+  * all fields of an entry must be filled in
+    * _error text:_ "no scheme given"
+    * _error text:_ "no north coordinate given"
+    * _error text:_ "no east coordinate given"
+    * _error text:_ "no south coordinate given"
+    * _error text:_ "no west coordinate given"
+
+### Privacy sensitive data form
+
+* **privacySensitiveDataPresent**
+  * mandatory radio button
+    * _error text:_ "please determine whether privacy sensitive data is present in this deposit"
+
+### Accept deposit agreement form
+
+* **acceptDepositAgreement**
+  * mandatory checkbox
+    * _error text:_ "Accept the deposit agreement before submitting this dataset"

--- a/doc/validation.md
+++ b/doc/validation.md
@@ -34,15 +34,17 @@ Deposit form
   * mandatory field
     * _error text:_ "no description was provided"
 * **contributors**
-  * mandatory field array
-    * _error text:_ "no contributors were provided"
-  * one creator minimum
+  * mandatory field array: at least one person or organization must be added to the form
+    * _error text:_ "no person or organization details were provided"
+  * one creator minimum: at least one contributor must have the role 'Creator'
     * _error text:_ "at least one creator is required"
-  * every nonempty contributor must have either an organization or {initial, surname}
+  * every contributor must have at least either an organization or {initial, surname}. All three
+    errors are given when only non-required fields are filled in; the second error is shown when
+    'surname' is provided, but 'initials' is not (and vise versa regarding the third error)
     * _error text:_ "no organization given"
     * _error text:_ "no initials given"
     * _error text:_ "no surname given"
-  * no partially filled in identifiers
+  * no partial identifiers
     * _error text:_ "no scheme given"
     * _error text:_ "no identifier given"
 * **dateCreated**
@@ -81,11 +83,13 @@ Deposit form
 ### License and access form
 
 * **rightsHolders**
-  * every nonempty contributor must have either an organization or {initial, surname}
+  * every contributor must have at least either an organization or {initial, surname}. All three
+    errors are given when only non-required fields are filled in; the second error is shown when
+    'surname' is provided, but 'initials' is not (and vise versa regarding the third error)
     * _error text:_ "no organization given"
     * _error text:_ "no initials given"
     * _error text:_ "no surname given"
-  * every nonempty contributor must have no partially filled in identifiers
+  * no partial identifiers
     * _error text:_ "no scheme given"
     * _error text:_ "no identifier given"
 * **accessRights**

--- a/doc/validation.md
+++ b/doc/validation.md
@@ -58,12 +58,14 @@ Deposit form
     * _error text:_ "no scheme given"
     * _error text:_ "no identifier given"
 * **relatedIdentifiers**
-  * if it has one element, only validate if either `scheme` or `value` is filled in
+  * if it has one element, only validate iff either `scheme` or `value` is filled in;
+    validate always when multiple elements are given
   * no partially filled in identifiers
     * _error text:_ "no scheme given"
     * _error text:_ "no identifier given"
 * **relations**
-  * if it has one element, only validate if either `title` or `url` is filled in
+  * if it has one element, only validate iff either `title` or `url` is filled in;
+    validate always when multiple elements are given
   * only a qualifier is selected
     * _error text:_ "no title given"
     * _error text:_ "no url given"

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -68,7 +68,7 @@ const checkNonEmpty: (s: string | undefined) => boolean = s => s ? s.trim() !== 
 
 export const atLeastOnePersonOrOrganization = (contributors?: Contributor[]) => {
     if (!contributors)
-        return "no contributors were provided"
+        return "no person or organization details were provided"
     else {
         const nonEmptyContributors = contributors.map(contributor => {
             const nonEmptyOrganization = checkNonEmpty(contributor.organization)
@@ -90,7 +90,7 @@ export const atLeastOnePersonOrOrganization = (contributors?: Contributor[]) => 
         }).reduce((prev, curr) => prev || curr, false)
 
         if (!nonEmptyContributors)
-            return "no contributors were provided"
+            return "no person or organization details were provided"
         else
             return undefined
     }

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -66,7 +66,7 @@ export const dateAvailableMustBeAfterDateCreated = (dateCreated?: Date, dateAvai
 
 const checkNonEmpty: (s: string | undefined) => boolean = s => s ? s.trim() !== "" : false
 
-export const atLeastOneContributor = (contributors?: Contributor[]) => {
+export const atLeastOnePersonOrOrganization = (contributors?: Contributor[]) => {
     if (!contributors)
         return "no contributors were provided"
     else {
@@ -119,12 +119,14 @@ export const validateContributors: (contributors: Contributor[]) => Contributor[
         const nonEmptyInsertions = checkNonEmpty(contributor.insertions)
         const nonEmptySurname = checkNonEmpty(contributor.surname)
         const nonEmptyIdentifiers = (contributor.ids || []).reduce(((p, id) => p || checkNonEmpty(id.scheme) || checkNonEmpty(id.value)), false)
+        const nonEmptyRole = checkNonEmpty(contributor.role)
         const nonEmptyContributor = nonEmptyOrganization
             || nonEmptyTitles
             || nonEmptyInitials
             || nonEmptyInsertions
             || nonEmptySurname
             || nonEmptyIdentifiers
+            || nonEmptyRole
 
         const contribError: Contributor = {}
 
@@ -310,7 +312,7 @@ export const formValidate: (values: DepositFormMetadata) => FormErrors<DepositFo
     errors.titles = { _error: mandatoryFieldArrayValidator(values.titles, "titles") }
     errors.description = mandatoryFieldValidator(values.description, "description")
     if (values.contributors) {
-        const oneContributor = atLeastOneContributor(values.contributors)
+        const oneContributor = atLeastOnePersonOrOrganization(values.contributors)
         const oneCreator = atLeastOneCreator(values.contributors)
 
         if (oneContributor)

--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -119,7 +119,7 @@ const BasicInformationForm = ({ depositId, languages, contributorIds, contributo
                component={TextArea}/>
 
         <RepeatableFieldWithDropdown name="contributors"
-                                     label="People & organisations"
+                                     label="People & organizations"
                                      helpText
                                      mandatory
                                      empty={() => emptyContributor}

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -197,15 +197,15 @@ describe("Validation", () => {
         })
 
         it("should return an error when undefined is given", () => {
-            expect(atLeastOnePersonOrOrganization(undefined)).to.eql("no contributors were provided")
+            expect(atLeastOnePersonOrOrganization(undefined)).to.eql("no person or organization details were provided")
         })
 
         it("should return an error when an empty list is given", () => {
-            expect(atLeastOnePersonOrOrganization([])).to.eql("no contributors were provided")
+            expect(atLeastOnePersonOrOrganization([])).to.eql("no person or organization details were provided")
         })
 
         it("should return an error when only empty Contributors are given", () => {
-            expect(atLeastOnePersonOrOrganization([contributor3, contributor4])).to.eql("no contributors were provided")
+            expect(atLeastOnePersonOrOrganization([contributor3, contributor4])).to.eql("no person or organization details were provided")
         })
     })
 

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -16,7 +16,7 @@
 import { expect } from "chai"
 import { describe, it } from "mocha"
 import {
-    atLeastOneContributor,
+    atLeastOnePersonOrOrganization,
     atLeastOneCreator,
     checkboxMustBeChecked,
     dateAvailableMustBeAfterDateCreated,
@@ -193,19 +193,19 @@ describe("Validation", () => {
         const contributor4: Contributor = {}
 
         it("should return undefined when at least one Contributor is not empty", () => {
-            expect(atLeastOneContributor([contributor1, contributor2, contributor3, contributor4])).to.be.undefined
+            expect(atLeastOnePersonOrOrganization([contributor1, contributor2, contributor3, contributor4])).to.be.undefined
         })
 
         it("should return an error when undefined is given", () => {
-            expect(atLeastOneContributor(undefined)).to.eql("no contributors were provided")
+            expect(atLeastOnePersonOrOrganization(undefined)).to.eql("no contributors were provided")
         })
 
         it("should return an error when an empty list is given", () => {
-            expect(atLeastOneContributor([])).to.eql("no contributors were provided")
+            expect(atLeastOnePersonOrOrganization([])).to.eql("no contributors were provided")
         })
 
         it("should return an error when only empty Contributors are given", () => {
-            expect(atLeastOneContributor([contributor3, contributor4])).to.eql("no contributors were provided")
+            expect(atLeastOnePersonOrOrganization([contributor3, contributor4])).to.eql("no contributors were provided")
         })
     })
 


### PR DESCRIPTION
Fixes EASY-1915

#### When applied it will
* describe validation messages
* replace all occurrences of `organisation` with `organization`
* include `nonEmptyRole` in contributor validation

@DANS-KNAW/easy for review