### PR TITLE
EASY-1902: flatten external representation of metadata field 'accessRights'

### DIFF
--- a/src/main/typescript/lib/metadata/AccessRight.ts
+++ b/src/main/typescript/lib/metadata/AccessRight.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { clean } from "./misc"
-
 export interface AccessRight {
     category?: AccessRightValue
 }
@@ -29,7 +27,7 @@ function toAccessRight(value: string): AccessRightValue | undefined {
 }
 
 export const accessRightConverter: (ar: any) => AccessRight = ar => {
-    const category = toAccessRight(ar.category)
+    const category = toAccessRight(ar)
     if (category)
         return {
             category: category,
@@ -39,7 +37,5 @@ export const accessRightConverter: (ar: any) => AccessRight = ar => {
 }
 
 export const accessRightDeconverter: (ar: AccessRight) => any = ar => {
-    return clean({
-        category: ar.category,
-    })
+    return ar.category
 }

--- a/src/test/typescript/lib/metadata/AccessRight.spec.ts
+++ b/src/test/typescript/lib/metadata/AccessRight.spec.ts
@@ -26,9 +26,7 @@ describe("AccessRight", () => {
     describe("accessRightConverter", () => {
 
         it("should convert a valid open-access", () => {
-            const input = {
-                category: "OPEN_ACCESS",
-            }
+            const input = "OPEN_ACCESS"
             const expected = {
                 category: "OPEN_ACCESS",
             }
@@ -55,12 +53,11 @@ describe("AccessRight", () => {
     describe("accessRightDeconverter", () => {
 
         it("should convert an empty AccessRight to an empty output", () => {
-            expect(accessRightDeconverter({})).to.eql({})
+            expect(accessRightDeconverter({})).to.eql(undefined)
         })
 
         it("should convert an AccessRight with only a category into the correct external model", () => {
-            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS })).to
-                .eql({ category: "OPEN_ACCESS" })
+            expect(accessRightDeconverter({ category: AccessRightValue.OPEN_ACCESS })).to.eql("OPEN_ACCESS")
         })
     })
 })

--- a/src/test/typescript/mockserver/metadata.ts
+++ b/src/test/typescript/mockserver/metadata.ts
@@ -63,7 +63,7 @@ export interface Metadata {
 
     // license and access
     publishers?: string[]
-    accessRights?: AccessRight
+    accessRights?: AccessRightValues
     license?: string
 
     // Upload types
@@ -214,10 +214,6 @@ enum DateQualifierValues {
 
 enum DateSchemeValues {
     W3CDTF = "dcterms:W3CDTF"
-}
-
-interface AccessRight {
-    category: AccessRightValues
 }
 
 enum AccessRightValues {
@@ -476,9 +472,7 @@ export const allfields: Metadata = {
         "pub1",
         "pub2",
     ],
-    accessRights: {
-        category: AccessRightValues.OPEN_ACCESS,
-    },
+    accessRights: AccessRightValues.OPEN_ACCESS,
     license: "http://creativecommons.org/publicdomain/zero/1.0",
     types: [
         {
@@ -645,9 +639,7 @@ export const mandatoryOnly: Metadata = {
             qualifier: DateQualifierValues.available,
         },
     ],
-    accessRights: {
-        category: AccessRightValues.REQUEST_PERMISSION,
-    },
+    accessRights: AccessRightValues.REQUEST_PERMISSION,
     license: "http://creativecommons.org/publicdomain/zero/1.0",
     privacySensitiveDataPresent: PrivacySensitiveDataValues.YES,
     // acceptDepositAgreement: false, // if not set, this value is false by default


### PR DESCRIPTION
Fixes EASY-1902

#### When applied it will
* flatten the external representation of metadata field `accessRights`
* _I left the internal representation untouched, because that form already is frightening complex_

@DANS-KNAW/easy for review

See also https://github.com/DANS-KNAW/easy-deposit-api/pull/122