### PR TITLE
EASY-2020: proper regex patterns for contributorIds

### DIFF
--- a/src/main/resources/constants/contributorIds.json
+++ b/src/main/resources/constants/contributorIds.json
@@ -2,16 +2,19 @@
   "id-type:DAI": {
     "title": "DAI",
     "viewName": "DAI",
-    "format": "^[0-9]{8,9}[0-9xX]$"
+    "format": "^(info:eu-repo/dai/nl/)?[0-9]{8,9}[0-9xX]$",
+    "placeholder": "DAI (info:eu-repo/dai/nl/358163587)"
   },
   "id-type:ORCID": {
     "title": "ORCID",
     "viewName": "ORCID",
-    "format": "^([0-9]{4}-){3}[0-9]{3}[0-9xX]?$"
+    "format": "^(https://orcid.org/)?([0-9]{4}-){3}[0-9]{3}[0-9xX]?$",
+    "placeholder": "ORCID (0000-0002-1825-0097)"
   },
   "id-type:ISNI": {
     "title": "ISNI",
     "viewName": "ISNI",
-    "format": "(^[0-9]{15,16}X?$)|(^([0-9]{4}[ ]?){3}[0-9]{3}[0-9xX]$)"
+    "format": "(^(http://isni.org/isni/|ISNI:)[0-9]{15,16}X?$)|(^([0-9]{4}[ ]?){3}[0-9]{3}[0-9xX]$)",
+    "placeholder": "ISNI (ISNI:000000012281955X)"
   }
 }

--- a/src/main/resources/constants/contributorIds.json
+++ b/src/main/resources/constants/contributorIds.json
@@ -2,16 +2,16 @@
   "id-type:DAI": {
     "title": "DAI",
     "viewName": "DAI",
-    "format": "^([0-9]{4}-){3}[0-9]{3}[0-9xX]?$"
+    "format": "^[0-9]{8,9}[0-9xX]$"
   },
   "id-type:ORCID": {
     "title": "ORCID",
     "viewName": "ORCID",
-    "format": "(^([0-9]){15,16}X?$)|(^([0-9]{4}[ ]?){3}[0-9]{3}[0-9xX]$)"
+    "format": "^([0-9]{4}-){3}[0-9]{3}[0-9xX]?$"
   },
   "id-type:ISNI": {
     "title": "ISNI",
     "viewName": "ISNI",
-    "format": "^([0-9]{8,9})([0-9xX])$"
+    "format": "(^[0-9]{15,16}X?$)|(^([0-9]{4}[ ]?){3}[0-9]{3}[0-9xX]$)"
   }
 }

--- a/src/main/typescript/lib/dropdown/dropdown.ts
+++ b/src/main/typescript/lib/dropdown/dropdown.ts
@@ -42,6 +42,7 @@ export const convertContributorIdDropdownData: (data: any) => ContributorIdDropd
                 value: obj.title,
                 displayValue: obj.viewName,
                 format: obj.format,
+                placeholder: obj.placeholder,
             }
         })
 }

--- a/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
@@ -33,10 +33,8 @@ function getPlaceholder(fields: FieldArrayFieldsProps<SchemedValue>, index: numb
         const scheme = contributorId.scheme
         if (scheme) {
             const contributorEntry = contributorIds.find(({ key }) => key == scheme)
-            if (contributorEntry) {
-                console.log(`placeholder: ${contributorEntry.placeholder}`)
+            if (contributorEntry)
                 return contributorEntry.placeholder
-            }
         }
     }
     return "ID"

--- a/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
@@ -15,7 +15,7 @@
  */
 import * as React from "react"
 import asFieldArray, { InnerComponentProps } from "./FieldArrayHOC"
-import { Field } from "redux-form"
+import { Field, FieldArrayFieldsProps } from "redux-form"
 import TextField, { ErrorHandlingTextField } from "./TextField"
 import { DropdownFieldInput, ErrorHandlingDropdownFieldInput } from "./DropDownField"
 import { ContributorIdDropdownListEntry, DropdownListEntry } from "../../model/DropdownLists"
@@ -25,6 +25,22 @@ import { emptySchemedValue, SchemedValue } from "../metadata/Value"
 import AddButton from "./AddButton"
 import Mandatory from "./Mandatory"
 import { Contributor } from "../metadata/Contributor"
+
+function getPlaceholder(fields: FieldArrayFieldsProps<SchemedValue>, index: number, contributorIds: ContributorIdDropdownListEntry[]): string {
+    const contributorId = fields.get(index)
+
+    if (contributorId) {
+        const scheme = contributorId.scheme
+        if (scheme) {
+            const contributorEntry = contributorIds.find(({ key }) => key == scheme)
+            if (contributorEntry) {
+                console.log(`placeholder: ${contributorEntry.placeholder}`)
+                return contributorEntry.placeholder
+            }
+        }
+    }
+    return "ID"
+}
 
 const ContributorIdArray = ({ fields, fieldNames, empty, dropdowns: { contributorIds } }: FieldArrayPropsWithDropdown<SchemedValue, ContributorIdDropdownListEntry[]>) => (
     <>
@@ -45,7 +61,7 @@ const ContributorIdArray = ({ fields, fieldNames, empty, dropdowns: { contributo
 
                 <div className="col col-12 col-md-6">
                     <Field name={fieldNames[1](name)}
-                           placeholder="ID"
+                           placeholder={getPlaceholder(fields, index, contributorIds)}
                            component={ErrorHandlingTextField}/>
                 </div>
 

--- a/src/main/typescript/model/DropdownLists.ts
+++ b/src/main/typescript/model/DropdownLists.ts
@@ -32,6 +32,7 @@ export interface DropdownListEntry {
 
 export interface ContributorIdDropdownListEntry extends DropdownListEntry {
     format: string
+    placeholder: string
 }
 
 export interface SpatialCoordinatesDropdownListEntry extends DropdownListEntry {

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -264,19 +264,22 @@ describe("Validation", () => {
             key: "id-type:DAI",
             value: "DAI",
             displayValue: "DAI",
-            format: "^([0-9]{4}-){3}[0-9]{3}[0-9xX]?$",
+            format: "^(info:eu-repo/dai/nl/)?[0-9]{8,9}[0-9xX]$",
+            placeholder: "DAI (info:eu-repo/dai/nl/358163587)",
         },
         {
             key: "id-type:ORCID",
             value: "ORCID",
             displayValue: "ORCID",
-            format: "(^([0-9]){15,16}X?$)|(^([0-9]{4}[ ]?){3}[0-9]{3}[0-9xX]$)",
+            format: "^(https://orcid.org/)?([0-9]{4}-){3}[0-9]{3}[0-9xX]?$",
+            placeholder: "ORCID (0000-0002-1825-0097)"
         },
         {
             key: "id-type:ISNI",
             value: "ISNI",
             displayValue: "ISNI",
-            format: "^([0-9]{8,9})([0-9xX])$",
+            format: "(^(http://isni.org/isni/|ISNI:)[0-9]{15,16}X?$)|(^([0-9]{4}[ ]?){3}[0-9]{3}[0-9xX]$)",
+            placeholder: "ISNI (ISNI:000000012281955X)"
         },
     ]
 
@@ -298,7 +301,7 @@ describe("Validation", () => {
                     // no value
                 },
                 {
-                    scheme: "id-type:ISNI",
+                    scheme: "id-type:DAI",
                     value: "012345678X",
                 },
                 {


### PR DESCRIPTION
Fixes EASY-2020

#### When applied it will
* fix the regex patterns for checking the validity of the contributor identifiers
* add placeholders with examples for every type of contributor identifier (see examples below)

@DANS-KNAW/easy for review

![image](https://user-images.githubusercontent.com/5938204/55237514-9f8a6380-5232-11e9-8a0c-00f23595b0b4.png)

![image](https://user-images.githubusercontent.com/5938204/55237527-a618db00-5232-11e9-8258-e2d16bbde23c.png)

![image](https://user-images.githubusercontent.com/5938204/55237541-ab762580-5232-11e9-88bf-790ca9ca9280.png)

![image](https://user-images.githubusercontent.com/5938204/55237550-b3ce6080-5232-11e9-9cd7-40136a3d43f9.png)