### PR TITLE
EASY-1871: run 'npm version' command to make package.json version conform to the version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,23 @@
                         </configuration>
                     </execution>
 
+                    <execution>
+                        <id>npm version (initialize)</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>version</argument>
+                                <argument>--no-git-tag-version</argument>
+                                <argument>--allow-same-version</argument>
+                                <argument>${project.version}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+
                     <!-- This following calls `npm run build` where 'build' is the script name
                          we defined in package.json -->
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,9 @@
                         </configuration>
                     </execution>
 
+                    <!-- The following will ensure that the project's version as defined here in this pom.xml
+                         is also stated in package.json. This is in turn used to display the version in the footer
+                         of the UI. -->
                     <execution>
                         <id>npm version (initialize)</id>
                         <goals>


### PR DESCRIPTION
Fixes EASY-1871

#### When applied it will
* run `npm version` command to make the version in `package.json` conform to the version in `pom.xml`

@DANS-KNAW/easy for review

![image](https://user-images.githubusercontent.com/5938204/55238512-03159080-5235-11e9-8688-1d9587a16b58.png)