### PR TITLE
EASY-1843: proper error message when backend service is unavailable

### DIFF
--- a/src/main/typescript/actions/authenticationActions.ts
+++ b/src/main/typescript/actions/authenticationActions.ts
@@ -15,10 +15,10 @@
  */
 import { ComplexThunkAction, PromiseAction, ThunkAction } from "../lib/redux"
 import { AuthenticationConstants } from "../constants/authenticationConstants"
-import axios from "axios"
 import { loginUrl, logoutUrl, userUrl } from "../selectors/serverRoutes"
 import { UserConstants } from "../constants/userConstants"
 import { userConverter } from "../lib/user/user"
+import fetch from "../lib/fetch"
 import LocalStorage from "../lib/LocalStorage"
 
 const authenticatePending = ({
@@ -67,7 +67,7 @@ export const authenticate: (userName: string, password: string) => ComplexThunkA
     dispatch(authenticatePending)
 
     try {
-        await axios.post(loginUrl(getState()), {}, {
+        await fetch.post(loginUrl(getState()), {}, {
             auth: {
                 password: password,
                 username: userName,
@@ -77,7 +77,7 @@ export const authenticate: (userName: string, password: string) => ComplexThunkA
         dispatch(userPending)
 
         try {
-            const userResponse = await axios.get(userUrl(getState()))
+            const userResponse = await fetch.get(userUrl(getState()))
 
             dispatch(userFulfilled(userResponse.data))
             dispatch(authenticateFulfilled)
@@ -101,7 +101,7 @@ export const signout: () => ThunkAction<PromiseAction<void>> = () => (dispatch, 
     type: AuthenticationConstants.AUTH_LOGOUT,
     async payload() {
         try {
-            await axios.post(logoutUrl(getState()))
+            await fetch.post(logoutUrl(getState()))
             LocalStorage.setLogout()
         }
         catch (logoutResponse) {
@@ -130,7 +130,7 @@ export const getUser: () => ComplexThunkAction = () => async (dispatch, getState
     dispatch(userPending)
 
     try {
-        const response = await axios.get(userUrl(getState()))
+        const response = await fetch.get(userUrl(getState()))
         dispatch(userFulfilled(response.data))
     }
     catch (response) {

--- a/src/main/typescript/actions/configurationActions.ts
+++ b/src/main/typescript/actions/configurationActions.ts
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import axios from "axios"
 import { FetchAction } from "../lib/redux"
 import { ConfigurationConstants } from "../constants/configurationConstants"
 import { Configuration } from "../model/Configuration"
 import { configurationConverter } from "../lib/configuration/configuration"
+import fetch from "../lib/fetch"
 
 export const fetchConfiguration: () => FetchAction<Configuration> = () => ({
     type: ConfigurationConstants.CONFIGURATION_LOADING,
     async payload() {
-        const response = await axios.get(require(`../../resources/application.json`))
+        const response = await fetch.get(require(`../../resources/application.json`))
         return response.data
     },
     meta: {

--- a/src/main/typescript/actions/depositFormActions.ts
+++ b/src/main/typescript/actions/depositFormActions.ts
@@ -18,11 +18,11 @@ import { DepositFormMetadata } from "../components/form/parts"
 import { FetchAction, PromiseAction, ReduxAction, ThunkAction } from "../lib/redux"
 import { DepositFormConstants } from "../constants/depositFormConstants"
 import { DepositId } from "../model/Deposits"
-import axios from "axios"
 import { Action } from "redux"
 import { AppState } from "../model/AppState"
 import { metadataConverter, metadataDeconverter } from "../lib/metadata/Metadata"
 import { Doi } from "../lib/metadata/Identifier"
+import fetch from "../lib/fetch"
 import { fetchDoiUrl, fetchMetadataUrl, saveDraftUrl, submitDepositUrl } from "../selectors/serverRoutes"
 
 export const unregisterForm: () => Action = () => ({
@@ -32,7 +32,7 @@ export const unregisterForm: () => Action = () => ({
 export const fetchMetadata: (depositId: DepositId) => ThunkAction<FetchAction<DepositFormMetadata, AppState>> = depositId => (dispatch, getState) => dispatch({
     type: DepositFormConstants.FETCH_METADATA,
     async payload() {
-        const response = await axios.get(fetchMetadataUrl(depositId)(getState()))
+        const response = await fetch.get(fetchMetadataUrl(depositId)(getState()))
         return response.data
     },
     meta: {
@@ -50,7 +50,7 @@ export const fetchMetadata: (depositId: DepositId) => ThunkAction<FetchAction<De
 export const fetchDoi: (depositId: DepositId) => ThunkAction<FetchAction<Doi>> = depositId => (dispatch, getState) => dispatch({
     type: DepositFormConstants.FETCH_DOI,
     async payload() {
-        const response = await axios.get(fetchDoiUrl(depositId)(getState()))
+        const response = await fetch.get(fetchDoiUrl(depositId)(getState()))
         return response.data
     },
     meta: {
@@ -68,7 +68,7 @@ export const saveDraft: (depositId: DepositId, data: DepositFormMetadata) => Thu
         return dispatch({
             type: DepositFormConstants.SAVE_DRAFT,
             async payload() {
-                const response = await axios.put(saveDraftUrl(depositId)(getState()), output)
+                const response = await fetch.put(saveDraftUrl(depositId)(getState()), output)
                 return response.data
             },
         })
@@ -100,12 +100,12 @@ export const submitDeposit: (depositId: DepositId, data: DepositFormMetadata, hi
         return dispatch({
             type: DepositFormConstants.SUBMIT_DEPOSIT,
             async payload() {
-                await axios.put(saveDraftUrl(depositId)(getState()), output)
+                await fetch.put(saveDraftUrl(depositId)(getState()), output)
                 const submitState = {
                     state: "SUBMITTED",
                     stateDescription: "Deposit is ready for post-submission processing",
                 }
-                const response = await axios.put(submitDepositUrl(depositId)(getState()), submitState)
+                const response = await fetch.put(submitDepositUrl(depositId)(getState()), submitState)
                 return response.data
             },
             meta: {

--- a/src/main/typescript/actions/depositOverviewActions.ts
+++ b/src/main/typescript/actions/depositOverviewActions.ts
@@ -16,16 +16,16 @@
 import * as H from "history"
 import { FetchAction, PromiseAction, ThunkAction } from "../lib/redux"
 import { DepositOverviewConstants } from "../constants/depositOverviewConstants"
-import axios from "axios"
 import { DepositId, Deposits } from "../model/Deposits"
 import { Action } from "redux"
 import { depositsConverter, newDepositConverter } from "../lib/deposits/deposits"
+import fetch from "../lib/fetch"
 import { deleteDepositUrl, listDepositUrl, newDepositUrl } from "../selectors/serverRoutes"
 
 export const fetchDeposits: () => ThunkAction<FetchAction<Deposits>> = () => (dispatch, getState) => dispatch({
     type: DepositOverviewConstants.FETCH_DEPOSITS,
     async payload() {
-        const response = await axios.get(listDepositUrl(getState()))
+        const response = await fetch.get(listDepositUrl(getState()))
         return response.data
     },
     meta: {
@@ -40,7 +40,7 @@ export const cleanDeposits: () => Action = () => ({
 export const deleteDeposit: (depositId: DepositId) => ThunkAction<PromiseAction<void>> = depositId => (dispatch, getState) => dispatch({
     type: DepositOverviewConstants.DELETE_DEPOSIT,
     async payload() {
-        await axios.delete(deleteDepositUrl(depositId)(getState()))
+        await fetch.delete(deleteDepositUrl(depositId)(getState()))
     },
     meta: { depositId: depositId },
 })
@@ -58,7 +58,7 @@ export const askConfirmationToDeleteDeposit: (depositId: DepositId) => Action = 
 export const createNewDeposit: (history: H.History) => ThunkAction<FetchAction<DepositId>> = history => (dispatch, getState) => dispatch({
     type: DepositOverviewConstants.CREATE_NEW_DEPOSIT,
     async payload() {
-        const response = await axios.post(newDepositUrl(getState()))
+        const response = await fetch.post(newDepositUrl(getState()))
         return response.data
     },
     meta: {

--- a/src/main/typescript/actions/dropdownActions.ts
+++ b/src/main/typescript/actions/dropdownActions.ts
@@ -15,7 +15,8 @@
  */
 import { DropdownConstants } from "../constants/dropdownConstants"
 import { ComplexThunkAction, FetchAction, PromiseThunkAction, ReduxAction } from "../lib/redux"
-import axios, { AxiosRequestConfig } from "axios"
+import fetch from "../lib/fetch"
+import { AxiosRequestConfig } from "axios"
 import {
     convertContributorIdDropdownData,
     convertDropdownData,
@@ -59,9 +60,10 @@ function fetchDropdown<Entry extends DropdownListEntry>(pending: DropdownConstan
 
             try {
                 const requestConfig: AxiosRequestConfig = { headers: { "Cache-Control": "no-cache" } }
-                const response = await axios.get(require(`../../resources/constants/${filename}`), requestConfig)
+                const response = await fetch.get(require(`../../resources/constants/${filename}`), requestConfig)
                 dispatch(fetchDropdownFulfilled(fulfilled, response.data, convertData))
-            } catch (e) {
+            }
+            catch (e) {
                 dispatch(fetchDropdownRejected(rejected, e))
             }
         }

--- a/src/main/typescript/actions/fileOverviewActions.ts
+++ b/src/main/typescript/actions/fileOverviewActions.ts
@@ -15,17 +15,17 @@
  */
 import { FetchAction, PromiseAction, ThunkAction } from "../lib/redux"
 import { FileOverviewConstants } from "../constants/fileOverviewConstants"
-import axios from "axios"
 import { Action } from "redux"
 import { DepositId } from "../model/Deposits"
 import { filesConverter } from "../lib/files/files"
+import fetch from "../lib/fetch"
 import { listFilesUrl, deleteFileUrl } from "../selectors/serverRoutes"
 import { Files } from "../model/FileInfo"
 
 export const fetchFiles: (depositId: DepositId) => ThunkAction<FetchAction<Files>> = (depositId) => (dispatch, getState) => dispatch({
     type: FileOverviewConstants.FETCH_FILES,
     async payload() {
-        const response = await axios.get(listFilesUrl(depositId)(getState()))
+        const response = await fetch.get(listFilesUrl(depositId)(getState()))
         return response.data
     },
     meta: {
@@ -36,7 +36,7 @@ export const fetchFiles: (depositId: DepositId) => ThunkAction<FetchAction<Files
 export const deleteFile: (depositId: DepositId, filePath: string) => ThunkAction<PromiseAction<void>> = (depositId, filePath) => (dispatch, getState) => dispatch({
     type: FileOverviewConstants.DELETE_FILE,
     async payload() {
-        await axios.delete(deleteFileUrl(depositId, filePath)(getState()))
+        await fetch.delete(deleteFileUrl(depositId, filePath)(getState()))
         dispatch(fetchFiles(depositId))
     },
     meta: { filePath: filePath },

--- a/src/main/typescript/actions/helpTextActions.ts
+++ b/src/main/typescript/actions/helpTextActions.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import { PromiseAction, ReduxAction } from "../lib/redux"
+import fetch from "../lib/fetch"
 import { HelpTextConstants } from "../constants/helpTextConstants"
-import axios, { AxiosRequestConfig } from "axios"
+import { AxiosRequestConfig } from "axios"
 
 export const registerHelpText: (fieldName: string) => ReduxAction<string> = fieldName => ({
     type: HelpTextConstants.REGISTER_HELP_TEXT,
@@ -31,7 +32,7 @@ export const fetchHelpText: (fieldName: string) => PromiseAction<void> = fieldNa
     type: HelpTextConstants.FETCH_HELP_TEXT,
     async payload() {
         const requestConfig: AxiosRequestConfig = { headers: { "Cache-Control": "no-cache" } }
-        const response = await axios.get(require(`../../resources/helptexts/${fieldName}.html`), requestConfig)
+        const response = await fetch.get(require(`../../resources/helptexts/${fieldName}.html`), requestConfig)
         return response.data
     },
     meta: {

--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -69,7 +69,7 @@ interface SaveDraftErrorProps {
 const SaveDraftError = ({ saveError }: SaveDraftErrorProps) => (
     saveError
         ? <Alert key="saveDraftError">
-            An error occurred: {saveError}. Cannot save the draft of this deposit. Please try again.
+            An error occurred: {saveError}. Cannot save the draft of this deposit.
         </Alert>
         : null
 )
@@ -81,7 +81,7 @@ interface SubmitErrorProps {
 const SubmitError = ({ submitError }: SubmitErrorProps) => (
     submitError
         ? <Alert key="submitError">
-            An error occurred: {submitError}. Cannot submit this deposit. Please try again.
+            An error occurred: {submitError}. Cannot submit this deposit.
         </Alert>
         : null
 )

--- a/src/main/typescript/components/overview/DepositOverview.tsx
+++ b/src/main/typescript/components/overview/DepositOverview.tsx
@@ -80,7 +80,7 @@ const DepositOverview = (props: DepositOverviewProps) => {
 
     const renderCreateNewError = () => props.deposits.creatingNew.createError && (
         <Alert key="createNewError">
-            An error occurred: {props.deposits.creatingNew.createError}. Cannot create a new dataset. Please try again.
+            An error occurred: {props.deposits.creatingNew.createError}. Cannot create a new dataset.
         </Alert>
     )
 

--- a/src/main/typescript/lib/fetch.ts
+++ b/src/main/typescript/lib/fetch.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
+
+function change503Response(e: any): void {
+    console.log(e.response)
+    if (e.response && e.response.status === 503)
+        e.response.data = "The server is temporarily unavailable"
+}
+
+async function runAxiosCall<T = any>(axiosPromise: () => Promise<AxiosResponse<T>>): Promise<AxiosResponse<T>> {
+    try {
+        return await axiosPromise()
+    }
+    catch (e) {
+        change503Response(e)
+        throw e
+    }
+}
+
+async function modifiedGet<T = any>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    return runAxiosCall(() => axios.get(url, config))
+}
+
+async function modifiedDelete(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> {
+    return runAxiosCall(() => axios.delete(url, config))
+}
+
+async function modifiedHead(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> {
+    return runAxiosCall(() => axios.head(url, config))
+}
+
+async function modifiedPost<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    return runAxiosCall(() => axios.post(url, data, config))
+}
+
+async function modifiedPut<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    return runAxiosCall(() => axios.put(url, data, config))
+}
+
+async function modifiedPatch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    return runAxiosCall(() => axios.patch(url, data, config))
+}
+
+export default ({
+    get: modifiedGet,
+    delete: modifiedDelete,
+    head: modifiedHead,
+    post: modifiedPost,
+    put: modifiedPut,
+    patch: modifiedPatch,
+})


### PR DESCRIPTION
Fixes EASY-1843

#### When applied it will
* display a proper error message when `easy-deposit-api` is temporarily unavailable

@DANS-KNAW/easy for review

![image](https://user-images.githubusercontent.com/5938204/55719577-e03a6780-59fe-11e9-93aa-a2a3c0e2b581.png)