### PR TITLE
EASY-2053: contains CLARIN metadata radio button disappears after trying to select option

### DIFF
--- a/src/main/typescript/components/form/parts/UploadTypeForm.tsx
+++ b/src/main/typescript/components/form/parts/UploadTypeForm.tsx
@@ -16,7 +16,7 @@
 import * as React from "react"
 import TextFieldArray from "../../../lib/formComponents/TextFieldArray"
 import { RepeatableField, RepeatableFieldWithDropdown } from "../../../lib/formComponents/ReduxFormUtils"
-import RadioChoices from "../../../lib/formComponents/RadioChoices"
+import RadioChoices, { RadioChoice } from "../../../lib/formComponents/RadioChoices"
 import { Field } from "redux-form"
 import { emptyString } from "../../../lib/metadata/misc"
 import DcmiTypesFieldArray from "./uploadType/DcmiTypesFieldArray"
@@ -42,7 +42,7 @@ interface UploadTypeFormProps {
     imtFormats: DropdownList
 }
 
-const clarinChoices = [
+const clarinChoices: RadioChoice[] = [
     {
         name: "no CLARIN metadata",
         title: false,

--- a/src/main/typescript/lib/formComponents/RadioChoices.tsx
+++ b/src/main/typescript/lib/formComponents/RadioChoices.tsx
@@ -28,7 +28,7 @@ export interface RadioProps {
     divClassName?: string
 }
 
-const RadioChoices = ({ input, meta, label, choices, divClassName }: FieldProps & RadioProps) => (
+const RadioChoices = ({ input, choices, divClassName }: FieldProps & RadioProps) => (
     <>
         {choices.map(({ name, title, value }) =>
             <div className={`form-check col-12 ${divClassName || ""}`}
@@ -38,7 +38,7 @@ const RadioChoices = ({ input, meta, label, choices, divClassName }: FieldProps 
                   * {...input} must come before value={title} and neither of them may be omitted.
                   */}
                 <input className="form-check-input" id={name || title.toString()} type="radio"
-                       {...input} value={title} checked={input.value === title}/>
+                       {...input} value={title} checked={input.value === title.toString()}/>
                 <label className="form-check-label" htmlFor={name || title.toString()}>{value}</label>
             </div>,
         )}


### PR DESCRIPTION
Fixes EASY-2053

#### When applied it will
* fix the CLARIN metadata radio button

@DANS-KNAW/easy for review

![Kapture 2019-04-23 at 12 10 07](https://user-images.githubusercontent.com/5938204/56573163-c6814e80-65c0-11e9-9470-1aec1e8ee031.gif)