### PR TITLE
EASY-2066: reintroduce icon css to make reload icon smaller

### DIFF
--- a/src/main/resources/css/depositOverviewPage.css
+++ b/src/main/resources/css/depositOverviewPage.css
@@ -18,6 +18,10 @@
     margin: 10px 0 20px;
 }
 
+.icon {
+    font-size: 1rem;
+}
+
 .deposit_table thead tr {
     background-image: var(--table-header-gradient);
 }

--- a/src/main/resources/css/depositOverviewPage.css
+++ b/src/main/resources/css/depositOverviewPage.css
@@ -18,10 +18,6 @@
     margin: 10px 0 20px;
 }
 
-.icon {
-    font-size: 1rem;
-}
-
 .deposit_table thead tr {
     background-image: var(--table-header-gradient);
 }
@@ -131,4 +127,5 @@
 /* reset the color for '.alert-dismissible .close' when it has a '.icon' */
 .alert-dismissible .close.icon {
     color: initial;
+    font-size: 1rem;
 }


### PR DESCRIPTION
Fixes EASY-2066

#### When applied it will
* revert a bit of https://github.com/DANS-KNAW/easy-deposit-ui/pull/132 to make the 'reload' icons in error bars not be too big.

@DANS-KNAW/easy for review