### PR TITLE
replace 'entries' by 'deposits'/'files' in pagination component and usages

### DIFF
--- a/src/main/typescript/components/Paginationable.tsx
+++ b/src/main/typescript/components/Paginationable.tsx
@@ -19,12 +19,13 @@ import { range } from "lodash"
 import "../../resources/css/paginationable.css"
 
 interface PaginationableProps<T> {
+    entryDescription: string
     pagesShown: number
     entries: T[]
     renderEntries: (entries: T[], entryCount: number) => any
 }
 
-function Paginationable<T>({ pagesShown, entries, renderEntries }: PaginationableProps<T>) {
+function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntries }: PaginationableProps<T>) {
     const [currentStartIndex, setCurrentStartIndex] = useState(0)
     const [entriesPerPage, setEntriesPerPage] = useState(10)
 
@@ -59,7 +60,7 @@ function Paginationable<T>({ pagesShown, entries, renderEntries }: Paginationabl
                 <option value={100}>100</option>
                 <option value={200}>200</option>
             </select>
-            {" entries"}
+            {` ${entryDescription}`}
         </label>
     )
 
@@ -67,7 +68,7 @@ function Paginationable<T>({ pagesShown, entries, renderEntries }: Paginationabl
         const startIndex = currentStartIndex + 1
         const endIndex = Math.min(entryCount, currentStartIndex + entriesPerPage)
 
-        return `Showing ${startIndex} to ${endIndex} of ${entryCount} entries`
+        return `Showing ${startIndex} to ${endIndex} of ${entryCount} ${entryDescription}`
     }
 
     const renderPagination = () => (

--- a/src/main/typescript/components/form/parts/fileUpload/overview/FilesOverview.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/overview/FilesOverview.tsx
@@ -114,7 +114,8 @@ class FilesOverview extends Component<FilesOverviewProps & FilesOverviewInputPro
     }
 
     private renderTableView = () => (
-        <Paginationable pagesShown={5}
+        <Paginationable entryDescription="files"
+                        pagesShown={5}
                         entries={this.props.files.loading.loaded ? Object.keys(this.props.files.files) : []}
                         renderEntries={this.renderTable}/>
     )

--- a/src/main/typescript/components/overview/DepositOverview.tsx
+++ b/src/main/typescript/components/overview/DepositOverview.tsx
@@ -119,7 +119,8 @@ const DepositOverview = (props: DepositOverviewProps) => {
     )
 
     const renderTableView = () => (
-        <Paginationable pagesShown={5}
+        <Paginationable entryDescription="deposits"
+                        pagesShown={5}
                         entries={props.deposits.loading.loaded ? Object.keys(props.deposits.deposits) : []}
                         renderEntries={renderTable}/>
     )


### PR DESCRIPTION
#### When applied it will
* not say '_entries_' in the pagination component anymore, but rather '_deposits_' or '_files_', depending on the usage

@DANS-KNAW/easy for review
@janvanmansum this is as discussed during our meeting

![image](https://user-images.githubusercontent.com/5938204/56958021-440d0780-6b49-11e9-8395-f465f56dd17e.png)

![image](https://user-images.githubusercontent.com/5938204/56958028-4bccac00-6b49-11e9-947b-6e5338209dd2.png)