### PR TITLE
EASY-2074: don't show entry counters on an empty table

### DIFF
--- a/src/main/typescript/components/Paginationable.tsx
+++ b/src/main/typescript/components/Paginationable.tsx
@@ -106,7 +106,7 @@ function Paginationable<T>({ pagesShown, entries, renderEntries }: Paginationabl
             {renderEntries(entriesToBeRendered, entryCount)}
             <div className="row ml-0 mr-0 paginationable_bottom">
                 <div className="col-12 col-sm-6 col-md-5 pl-3 show_entry_count_column">
-                    {renderShowingCount()}
+                    {entryCount > 0 && renderShowingCount()}
                 </div>
                 <div className="col-12 col-sm-6 col-md-7 pl-3 pr-sm-0 pr-md-3">
                     {maxPage > 1 && renderPagination()}

--- a/src/main/typescript/components/Paginationable.tsx
+++ b/src/main/typescript/components/Paginationable.tsx
@@ -30,6 +30,7 @@ function Paginationable<T>({ pagesShown, entries, renderEntries }: Paginationabl
 
     const entriesToBeRendered = entries.slice(currentStartIndex, currentStartIndex + entriesPerPage) // end index is exclusive
     const entryCount = entries.length
+    const currentEndIndex = Math.min(entryCount, currentStartIndex + entriesPerPage)
     const hasNextPage = currentStartIndex + entriesPerPage < entryCount
     const hasPreviousPage = currentStartIndex - entriesPerPage >= 0
     const maxPage = Math.ceil(entryCount / entriesPerPage)
@@ -65,9 +66,8 @@ function Paginationable<T>({ pagesShown, entries, renderEntries }: Paginationabl
 
     const renderShowingCount = () => {
         const startIndex = currentStartIndex + 1
-        const endIndex = Math.min(entryCount, currentStartIndex + entriesPerPage)
 
-        return `Showing ${startIndex} to ${endIndex} of ${entryCount} entries`
+        return `Showing ${startIndex} to ${currentEndIndex} of ${entryCount} entries`
     }
 
     const renderPagination = () => (

--- a/src/main/typescript/components/Paginationable.tsx
+++ b/src/main/typescript/components/Paginationable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { range } from "lodash"
 import "../../resources/css/paginationable.css"
 
@@ -49,6 +49,13 @@ function Paginationable<T>({ pagesShown, entries, renderEntries }: Paginationabl
 
         return range(start, end, 1)
     }
+
+    useEffect(() => {
+        if (currentStartIndex >= entryCount)
+            previousPage()
+        else if (currentStartIndex < 0)
+            nextPage()
+    })
 
     const renderShowEntriesDropdown = () => (
         <label className="mb-2">


### PR DESCRIPTION
Fixes EASY-2074

#### When applied it will
* no longer show entry counters on an empty table
* recover from invalid state

@DANS-KNAW/easy for review