### PR TITLE
EASY-2101: license field as schemed value

### DIFF
--- a/src/test/typescript/lib/metadata/License.spec.ts
+++ b/src/test/typescript/lib/metadata/License.spec.ts
@@ -36,15 +36,39 @@ describe("License", () => {
     describe("licenseConverter", () => {
 
         it("should convert a valid license object and extract the license key", () => {
-            const input = "http://creativecommons.org/publicdomain/zero/1.0"
+            const input = {
+                scheme: "dcterms:URI",
+                value: "http://creativecommons.org/publicdomain/zero/1.0",
+            }
             const expected = "http://creativecommons.org/publicdomain/zero/1.0"
             expect(licenseConverter(licenses)(input)).to.eql(expected)
         })
 
+        it("should accept the EASY license", () => {
+            const input = {
+                scheme: "dcterms:URI",
+                value: "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSlicenceagreementUK5.3DEF.pdf",
+            }
+            const expected = "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSlicenceagreementUK5.3DEF.pdf"
+            expect(licenseConverter(licenses)(input)).to.eql(expected)
+        })
+
         it("should fail when then license is unknown", () => {
-            const input = "invalid license"
+            const input = {
+                scheme: "dcterms:URI",
+                value: "invalid license",
+            }
             expect(() => licenseConverter(licenses)(input)).to
                 .throw("Error in metadata: no such license: 'invalid license'")
+        })
+
+        it("should fail when an unknown scheme is used", () => {
+            const input = {
+                scheme: "unknown",
+                value: "http://creativecommons.org/publicdomain/zero/1.0",
+            }
+            expect(() => licenseConverter(licenses)(input)).to
+                .throw("Error in metadata: unrecognized object: {\"scheme\":\"unknown\",\"value\":\"http://creativecommons.org/publicdomain/zero/1.0\"}")
         })
     })
 
@@ -52,7 +76,10 @@ describe("License", () => {
 
         it("should convert a license to the correct external model", () => {
             const input = "http://creativecommons.org/publicdomain/zero/1.0"
-            const expected = "http://creativecommons.org/publicdomain/zero/1.0"
+            const expected = {
+                scheme: "dcterms:URI",
+                value: "http://creativecommons.org/publicdomain/zero/1.0",
+            }
             expect(licenseDeconverter(licenses)(input)).to.eql(expected)
         })
 

--- a/src/test/typescript/mockserver/metadata.ts
+++ b/src/test/typescript/mockserver/metadata.ts
@@ -64,7 +64,7 @@ export interface Metadata {
     // license and access
     publishers?: string[]
     accessRights?: AccessRightValues
-    license?: string
+    license?: SchemedValue
 
     // Upload types
     types?: PossiblySchemedValue<TypesSchemeValues>[]
@@ -219,6 +219,10 @@ enum DateSchemeValues {
 enum AccessRightValues {
     OPEN_ACCESS = "OPEN_ACCESS",
     REQUEST_PERMISSION = "REQUEST_PERMISSION",
+}
+
+enum LicenseSchemeValues {
+    uri = "dcterms:URI"
 }
 
 enum TypesSchemeValues {
@@ -473,7 +477,10 @@ export const allfields: Metadata = {
         "pub2",
     ],
     accessRights: AccessRightValues.OPEN_ACCESS,
-    license: "http://creativecommons.org/publicdomain/zero/1.0",
+    license: {
+        scheme: LicenseSchemeValues.uri,
+        value: "http://creativecommons.org/publicdomain/zero/1.0",
+    },
     types: [
         {
             scheme: TypesSchemeValues.dcmi,
@@ -640,7 +647,10 @@ export const mandatoryOnly: Metadata = {
         },
     ],
     accessRights: AccessRightValues.REQUEST_PERMISSION,
-    license: "http://creativecommons.org/publicdomain/zero/1.0",
+    license: {
+        scheme: LicenseSchemeValues.uri,
+        value: "http://creativecommons.org/publicdomain/zero/1.0",
+    },
     privacySensitiveDataPresent: PrivacySensitiveDataValues.YES,
     // acceptDepositAgreement: false, // if not set, this value is false by default
 }


### PR DESCRIPTION
Fixes EASY-2101

#### When applied it will
* no longer accept the license as a `String`, but rather as a `SchemedValue`

@DANS-KNAW/easy for review