### PR TITLE
EASY-2080: disable submit/save buttons while uploading a file

### DIFF
--- a/src/main/resources/css/dansColors.css
+++ b/src/main/resources/css/dansColors.css
@@ -100,6 +100,7 @@
 .btn-primary.disabled, .btn-primary:disabled {
     background-color: var(--primary);
     border-color: var(--primary);
+    cursor: not-allowed;
 }
 .btn-primary:not(:disabled):not(.disabled):hover {
     background-color: var(--primary-hover);
@@ -119,14 +120,15 @@
     background-color: var(--dark);
     border-color: var(--dark);
     opacity: 0.25;
+    cursor: not-allowed;
 }
-.btn-dark:not(:disabled):hover, .btn-dark:not(.disabled):hover {
+.btn-dark:not(:disabled):not(.disabled):hover {
     background-color: var(--dark-hover);
     border-color: var(--dark);
     color: var(--dans-button-text-hover);
 }
 
-.btn-dark.bg-danger:not(:disabled):hover, .btn-dark.bg-danger:not(.disabled):hover {
+.btn-dark.bg-danger:not(:disabled):not(.disabled):hover {
     border-color: var(--danger-border);
 }
 
@@ -134,7 +136,7 @@
     background: var(--dans-red) var(--danger-gradient);
     color: var(--dans-white);
 }
-.btn-danger:not(.disabled):hover, .btn-danger:not(:disabled):hover {
+.btn-danger:not(.disabled):not(:disabled):hover {
     color: var(--dans-button-text-hover);
 }
 

--- a/src/main/typescript/actions/fileUploadActions.ts
+++ b/src/main/typescript/actions/fileUploadActions.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Action } from "redux"
+import { FileUploadConstants } from "../constants/fileUploadConstants"
+
+export const setFileUploadInProgress: (isUploading: boolean) => Action = (isUploading) => ({
+    type: FileUploadConstants.FILE_UPLOAD_IN_PROGRESS,
+    payload: {isUploading: isUploading}
+})

--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -47,6 +47,7 @@ import { Files, LoadingState as FileOverviewLoadingState } from "../../model/Fil
 import { fetchFiles } from "../../actions/fileOverviewActions"
 import { formValidate } from "./Validation"
 import { inDevelopmentMode } from "../../lib/config"
+import { isFileUploading } from "../../selectors/fileUploadSelectors"
 
 interface FetchDataErrorProps {
     fetchError?: string
@@ -107,6 +108,7 @@ const Loaded: FC<LoadedProps> = ({ loading, loaded, error, children }) => {
 interface DepositFormStoreArguments {
     formState: DepositFormState
     fileState: FileOverviewLoadingState
+    fileUploadInProgress: boolean
     formValues?: DepositFormMetadata
 
     fetchAllDropdownsAndMetadata: (depositId: DepositId) => ComplexThunkAction
@@ -176,6 +178,9 @@ class DepositForm extends Component<DepositFormProps> {
         const { loading: fetchingFiles, loaded: fetchedFiles, loadingError: fetchedFilesError } = this.props.fileState
         const { saving, saved, saveError } = this.props.formState.saveDraft
         const { submitting, submitError } = this.props.formState.submit
+        const fileUploadInProgress = this.props.fileUploadInProgress
+
+        const buttonDisabled = fetchedMetadataError != undefined || fetchingMetadata || saving || submitting || fileUploadInProgress
 
         return (
             <>
@@ -248,13 +253,13 @@ class DepositForm extends Component<DepositFormProps> {
                         <button type="button"
                                 className="btn btn-dark margin-top-bottom"
                                 onClick={this.save}
-                                disabled={fetchedMetadataError != undefined || fetchingMetadata || saving || submitting}>
+                                disabled={buttonDisabled}>
                             Save draft
                         </button>
                         <button type="button"
                                 className="btn btn-dark margin-top-bottom"
                                 onClick={this.props.handleSubmit(this.submit)}
-                                disabled={fetchedMetadataError != undefined || fetchingMetadata || saving || submitting}>
+                                disabled={buttonDisabled}>
                             Submit deposit
                         </button>
                     </div>
@@ -272,6 +277,7 @@ class DepositForm extends Component<DepositFormProps> {
 const mapStateToProps = (state: AppState) => ({
     formState: state.depositForm,
     fileState: state.files.loading,
+    fileUploadInProgress: isFileUploading(state),
     initialValues: state.depositForm.initialState.metadata,
     formValues: state.form.depositForm && state.form.depositForm.values,
     dropDowns: state.dropDowns, // used in validation

--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -265,6 +265,7 @@ class DepositForm extends Component<DepositFormProps> {
                     </div>
 
                     <div>
+                        {fileUploadInProgress && <p><i>Please wait until the file is uploaded</i></p>}
                         {saving && <p><i>Saving draft...</i></p>}
                         {saved && <p><i>Saved draft</i></p>}
                     </div>

--- a/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
@@ -26,6 +26,7 @@ import { Files } from "../../../../../model/FileInfo"
 import { Alert } from "../../../../Errors"
 import { Action } from "redux"
 import { setFileUploadInProgress } from "../../../../../actions/fileUploadActions"
+import { isFileUploading } from "../../../../../selectors/fileUploadSelectors"
 
 interface FileUploaderInputProps {
     depositId: DepositId
@@ -33,6 +34,7 @@ interface FileUploaderInputProps {
 
 interface FileUploaderProps {
     fileUploadUrl: string
+    fileIsUploading: boolean
     depositIsSaving: boolean
     depositIsSubmitting: boolean
 
@@ -80,7 +82,7 @@ const FileUploader = (props: FileUploaderProps & FileUploaderInputProps) => {
             <input type="file"
                    onChange={uploadFile}
                    id="file-upload"
-                   disabled={!!uploadingFile || props.depositIsSaving || props.depositIsSubmitting}
+                   disabled={props.fileIsUploading || props.depositIsSaving || props.depositIsSubmitting}
                    className="input-file"/>
             <label className="btn btn-dark mb-0" htmlFor="file-upload">
                 {/* SVG taken from https://tympanus.net/Tutorials/CustomFileInputs/ */}
@@ -121,6 +123,7 @@ const FileUploader = (props: FileUploaderProps & FileUploaderInputProps) => {
 
 const mapStateToProps = (state: AppState, ownProps: FileUploaderInputProps) => ({
     fileUploadUrl: uploadFileUrl(ownProps.depositId, "")(state),
+    fileIsUploading: isFileUploading(state),
     depositIsSaving: state.depositForm.saveDraft.saving,
     depositIsSubmitting: state.depositForm.submit.submitting,
 })

--- a/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
@@ -24,6 +24,8 @@ import { DepositId } from "../../../../../model/Deposits"
 import { FetchAction } from "../../../../../lib/redux"
 import { Files } from "../../../../../model/FileInfo"
 import { Alert } from "../../../../Errors"
+import { Action } from "redux"
+import { setFileUploadInProgress } from "../../../../../actions/fileUploadActions"
 
 interface FileUploaderInputProps {
     depositId: DepositId
@@ -31,8 +33,11 @@ interface FileUploaderInputProps {
 
 interface FileUploaderProps {
     fileUploadUrl: string
+    depositIsSaving: boolean
+    depositIsSubmitting: boolean
 
     fetchFiles: (depositId: DepositId) => FetchAction<Files>
+    setFileUploadInProgress: (isUploading: boolean) => Action
 }
 
 const FileUploader = (props: FileUploaderProps & FileUploaderInputProps) => {
@@ -40,6 +45,7 @@ const FileUploader = (props: FileUploaderProps & FileUploaderInputProps) => {
     const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined)
 
     const uploadFile = (e: ChangeEvent<HTMLInputElement>) => {
+        props.setFileUploadInProgress(true)
         const file = e.target.files && e.target.files[0]
         setUploadingFile(file || undefined)
         setErrorMessage(undefined)
@@ -49,15 +55,18 @@ const FileUploader = (props: FileUploaderProps & FileUploaderInputProps) => {
     const uploadFinished = () => {
         setUploadingFile(undefined)
         props.fetchFiles(props.depositId)
+        props.setFileUploadInProgress(false)
     }
 
     const uploadCanceled = () => {
         setUploadingFile(undefined)
+        props.setFileUploadInProgress(false)
     }
 
     const uploadFailed = (file: File) => (msg?: string) => {
         setUploadingFile(undefined)
         setErrorMessage(`An error occurred while uploading ${file.name}${msg ? `: ${msg}` : ""}`)
+        props.setFileUploadInProgress(false)
     }
 
     const renderUploadError = () => (
@@ -71,7 +80,7 @@ const FileUploader = (props: FileUploaderProps & FileUploaderInputProps) => {
             <input type="file"
                    onChange={uploadFile}
                    id="file-upload"
-                   disabled={!!uploadingFile}
+                   disabled={!!uploadingFile || props.depositIsSaving || props.depositIsSubmitting}
                    className="input-file"/>
             <label className="btn btn-dark mb-0" htmlFor="file-upload">
                 {/* SVG taken from https://tympanus.net/Tutorials/CustomFileInputs/ */}
@@ -112,6 +121,8 @@ const FileUploader = (props: FileUploaderProps & FileUploaderInputProps) => {
 
 const mapStateToProps = (state: AppState, ownProps: FileUploaderInputProps) => ({
     fileUploadUrl: uploadFileUrl(ownProps.depositId, "")(state),
+    depositIsSaving: state.depositForm.saveDraft.saving,
+    depositIsSubmitting: state.depositForm.submit.submitting,
 })
 
-export default connect(mapStateToProps, { fetchFiles })(FileUploader)
+export default connect(mapStateToProps, { fetchFiles, setFileUploadInProgress })(FileUploader)

--- a/src/main/typescript/constants/fileUploadConstants.ts
+++ b/src/main/typescript/constants/fileUploadConstants.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export enum FileUploadConstants {
+    FILE_UPLOAD_IN_PROGRESS = "FILE_UPLOAD_IN_PROGRESS",
+}

--- a/src/main/typescript/model/AppState.ts
+++ b/src/main/typescript/model/AppState.ts
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { empty as emptyAuthenticatedUser, Authentication } from "./Authentication"
-import { empty as emptyDeposits, DepositOverviewState } from "./Deposits"
+import { Authentication, empty as emptyAuthenticatedUser } from "./Authentication"
+import { DepositOverviewState, empty as emptyDeposits } from "./Deposits"
 import { empty as emptyFiles, FileOverviewState } from "./FileInfo"
-import { empty as emptyUser } from "./UserDetails"
-import { UserDetails } from "./UserDetails"
-import { empty as emptyDepositForm } from "./DepositForm"
-import { DepositFormState } from "./DepositForm"
+import { empty as emptyUser, UserDetails } from "./UserDetails"
+import { DepositFormState, empty as emptyDepositForm } from "./DepositForm"
 import { FormStateMap } from "redux-form/lib/reducer"
 import { DropdownLists, emptyDropdownLists } from "./DropdownLists"
-import { empty as emptyConfig, ConfigurationState } from "./Configuration"
+import { ConfigurationState, empty as emptyConfig } from "./Configuration"
 import { emptyHelpTexts, HelpTexts } from "./HelpTexts"
+import { empty as emptyFileUpload, FileUploadState } from "./FileUploadState"
 
 export interface AppState {
     configuration: ConfigurationState
@@ -31,6 +30,7 @@ export interface AppState {
     user: UserDetails
     deposits: DepositOverviewState
     files: FileOverviewState
+    fileUpload: FileUploadState,
     helpTexts: HelpTexts,
     depositForm: DepositFormState,
     form: FormStateMap
@@ -43,8 +43,9 @@ export const empty: AppState = {
     user: emptyUser,
     deposits: emptyDeposits,
     files: emptyFiles,
+    fileUpload: emptyFileUpload,
     helpTexts: emptyHelpTexts,
     depositForm: emptyDepositForm,
     form: {},
-    dropDowns: emptyDropdownLists
+    dropDowns: emptyDropdownLists,
 }

--- a/src/main/typescript/model/FileUploadState.ts
+++ b/src/main/typescript/model/FileUploadState.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface FileUploadState {
+    uploadInProgress: boolean
+}
+
+export const empty: FileUploadState = {
+    uploadInProgress: false,
+}

--- a/src/main/typescript/reducers/fileUploadReducer.ts
+++ b/src/main/typescript/reducers/fileUploadReducer.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { empty, FileUploadState } from "../model/FileUploadState"
+import { Reducer } from "redux"
+import { FileUploadConstants } from "../constants/fileUploadConstants"
+
+export const fileUploadReducer: Reducer<FileUploadState> = (state = empty, action) => {
+    switch (action.type) {
+        case FileUploadConstants.FILE_UPLOAD_IN_PROGRESS: {
+            return { ...state, uploadInProgress: action.payload.isUploading }
+        }
+        default:
+            return state
+    }
+}

--- a/src/main/typescript/reducers/index.ts
+++ b/src/main/typescript/reducers/index.ts
@@ -25,6 +25,7 @@ import { depositFormReducer } from "./depositFormReducer"
 import { allDropdownReducers } from "./dropdownReducer"
 import configurationReducer from "./configurationReducer"
 import { helpTextReducer } from "./helpTextReducer"
+import { fileUploadReducer } from "./fileUploadReducer"
 
 function changeReducer(state: FormState, action: AnyAction) {
     switch (action.type) {
@@ -33,8 +34,9 @@ function changeReducer(state: FormState, action: AnyAction) {
             const newState = immutable.set(state.fields, fieldName, true)
 
             return { ...state, fields: newState }
+        default:
+            return state
     }
-    return state
 }
 
 export default combineReducers({
@@ -47,6 +49,7 @@ export default combineReducers({
     }),
     deposits: depositOverviewReducer,
     files: fileOverviewReducer,
+    fileUpload: fileUploadReducer,
     helpTexts: helpTextReducer,
     depositForm: depositFormReducer,
     dropDowns: allDropdownReducers,

--- a/src/main/typescript/selectors/fileUploadSelectors.ts
+++ b/src/main/typescript/selectors/fileUploadSelectors.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AppState } from "../model/AppState"
+
+export const isFileUploading = (state: AppState) => state.fileUpload.uploadInProgress


### PR DESCRIPTION
Fixes EASY-2080

#### When applied it will
* store global state (in Redux) on whether a file is being uploaded right now
* disable the `save` and `submit` buttons when a file is being uploaded right now
* disable the `upload file` button when saving or submitting (as suggested by @jo-pol)

@DANS-KNAW/easy for review