### PR TITLE
EASY-2107: fix ranges for spatialCoordinates

### DIFF
--- a/src/main/resources/constants/spatialCoordinates.json
+++ b/src/main/resources/constants/spatialCoordinates.json
@@ -16,9 +16,9 @@
     "x-label": "Lat",
     "y-label": "Long",
     "step": "0.000001",
-    "x-min": -90,
-    "x-max": 90,
-    "y-min": -180,
-    "y-max": 180
+    "x-min": -180,
+    "x-max": 180,
+    "y-min": -90,
+    "y-max": 90
   }
 }


### PR DESCRIPTION
Fixes EASY-2107

#### When applied it will
* swap the ranges of `x-min`/`y-min` and `x-max`/`y-max`

@DANS-KNAW/easy for review