### PR TITLE
EASY-2087: "log out" with dirty deposit-form causes confirmation prompt, but logs out regardless of choice

### DIFF
--- a/src/main/typescript/Routes.tsx
+++ b/src/main/typescript/Routes.tsx
@@ -20,7 +20,8 @@ import LoginPage from "./components/login/LoginPage"
 import DepositFormPage from "./components/form/DepositFormPage"
 import DepositOverviewPage from "./components/overview/DepositOverviewPage"
 import NotFoundPage from "./components/NotFoundPage"
-import { depositFormRoute, depositOverviewRoute, homeRoute, loginRoute } from "./constants/clientRoutes"
+import SignoutPage from "./components/SignoutPage"
+import { depositFormRoute, depositOverviewRoute, homeRoute, loginRoute, signoutRoute } from "./constants/clientRoutes"
 import { easyHome } from "./lib/config"
 
 const Routes = () => (
@@ -34,6 +35,9 @@ const Routes = () => (
         <Route path={loginRoute}
                exact
                component={LoginPage}/>
+        <Route path={signoutRoute}
+               exact
+               component={SignoutPage}/>
         <PrivateRoute
             path={depositFormRoute(":depositId")} // this name matches the property in DepositFormPage.tsx/RouterParams
             redirectTo={loginRoute}

--- a/src/main/typescript/components/Header.tsx
+++ b/src/main/typescript/components/Header.tsx
@@ -18,10 +18,10 @@ import { FC, ImgHTMLAttributes, useEffect } from "react"
 import { Link, NavLinkProps } from "react-router-dom"
 import { AppState } from "../model/AppState"
 import { connect } from "react-redux"
-import { getUser, signout } from "../actions/authenticationActions"
+import { getUser } from "../actions/authenticationActions"
 import "../../resources/css/header"
-import { ComplexThunkAction, PromiseAction } from "../lib/redux"
-import { depositOverviewRoute, homeRoute, loginRoute } from "../constants/clientRoutes"
+import { ComplexThunkAction } from "../lib/redux"
+import { depositOverviewRoute, homeRoute, loginRoute, signoutRoute } from "../constants/clientRoutes"
 
 const logo_dans = require("../../resources/img/header/logo_dans.png")
 const logo_easy = require("../../resources/img/header/logo_easy.png")
@@ -83,11 +83,10 @@ interface HeaderProps {
     isLoggedIn: boolean
     loginName: string
 
-    signout: () => PromiseAction<void>
     getUser: () => ComplexThunkAction
 }
 
-const Header = ({ isLoggedIn, loginName, signout, getUser }: HeaderProps) => {
+const Header = ({ isLoggedIn, loginName, getUser }: HeaderProps) => {
     useEffect(() => {
         if (isLoggedIn && !loginName)
             getUser()
@@ -97,11 +96,10 @@ const Header = ({ isLoggedIn, loginName, signout, getUser }: HeaderProps) => {
         ? [
             <span key="loginName" className="navbar-text">{loginName}</span>,
             <NavBarLink key="my datasets" to={depositOverviewRoute}>My Datasets</NavBarLink>,
-            <Link onClick={signout}
-                  className="nav-link logoff"
-                  key="log out"
-                  to={homeRoute}
-                  title="Log out">Log out</Link>,
+            <NavBarLink className="logoff"
+                        key="log out"
+                        to={signoutRoute}
+                        title="Log out">Log out</NavBarLink>,
         ]
         : [
             <NavBarLink key="login" to={loginRoute} title="Login to EASY">Log in</NavBarLink>,
@@ -138,4 +136,4 @@ const mapStateToProps = (state: AppState) => {
     })
 }
 
-export default connect(mapStateToProps, { signout, getUser })(Header)
+export default connect(mapStateToProps, { getUser })(Header)

--- a/src/main/typescript/components/SignoutPage.tsx
+++ b/src/main/typescript/components/SignoutPage.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react"
+import { useEffect } from "react"
+import { connect } from "react-redux"
+import { Redirect, RouteComponentProps } from "react-router"
+import { signout } from "../actions/authenticationActions"
+import { homeRoute } from "../constants/clientRoutes"
+import { PromiseAction } from "../lib/redux"
+import { AppState } from "../model/AppState"
+
+interface SignoutPageProps extends RouteComponentProps {
+    isLoggedIn: boolean
+
+    signout: () => PromiseAction<void>
+}
+
+const SignoutPage = ({ isLoggedIn, signout, location }: SignoutPageProps) => {
+    useEffect(() => {
+        isLoggedIn && signout()
+    }, [])
+
+    return isLoggedIn
+        ? <p>still logged in</p>
+        : <Redirect to={{
+            pathname: homeRoute,
+            state: { from: location },
+        }}/>
+}
+
+const mapStateToProps = (state: AppState) => ({
+    isLoggedIn: state.authenticatedUser.isAuthenticated,
+})
+
+export default connect(mapStateToProps, { signout })(SignoutPage)

--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -31,7 +31,7 @@ import { ComplexThunkAction, FetchAction, PromiseAction, ReduxAction, ThunkActio
 import { saveDraft, submitDeposit } from "../../actions/depositFormActions"
 import { AppState } from "../../model/AppState"
 import { DepositFormState } from "../../model/DepositForm"
-import { Alert, ReloadAlert } from "../Errors"
+import { Alert } from "../Errors"
 import DepositLicenseForm from "./parts/DepositLicenseForm"
 import PrivacySensitiveDataForm from "./parts/PrivacySensitiveDataForm"
 import MessageForDataManagerForm from "./parts/MessageForDataManagerForm"
@@ -48,46 +48,6 @@ import { fetchFiles } from "../../actions/fileOverviewActions"
 import { formValidate } from "./Validation"
 import { inDevelopmentMode } from "../../lib/config"
 import { isFileUploading } from "../../selectors/fileUploadSelectors"
-
-interface FetchDataErrorProps {
-    fetchError?: string
-
-    reload: () => any
-}
-
-const FetchDataError = ({ fetchError, reload }: FetchDataErrorProps) => (
-    fetchError
-        ? <ReloadAlert key="fetchMetadataError" reload={reload}>
-            An error occurred: {fetchError}. Cannot load metadata from the server.
-        </ReloadAlert>
-        : null
-)
-
-interface SaveDraftErrorProps {
-    saveError?: string
-}
-
-const SaveDraftError = ({ saveError }: SaveDraftErrorProps) => (
-    saveError
-        ? <Alert key="saveDraftError">
-            An error occurred: {saveError}. Cannot save the draft of this deposit.
-        </Alert>
-        : null
-)
-
-interface SubmitErrorProps {
-    submitError?: string
-}
-
-const SubmitError = ({ submitError }: SubmitErrorProps) => (
-    submitError
-        ? <Alert key="submitError">
-            An error occurred: {submitError}. Cannot submit this deposit.
-        </Alert>
-        : null
-)
-
-const ValidationError = () => <Alert key="submitError">Cannot submit this deposit. Some fields are not filled in correctly.</Alert>
 
 interface LoadedProps {
     loading: boolean
@@ -187,8 +147,10 @@ class DepositForm extends Component<DepositFormProps> {
                 <Prompt when={this.shouldBlockNavigation()}
                         message={DepositForm.leaveMessage}/>
 
-                <FetchDataError fetchError={fetchedFilesError} reload={this.fetchFiles}/>
-                <FetchDataError fetchError={fetchedMetadataError} reload={this.fetchMetadata}/>
+                {/*@formatter:off*/}
+                {fetchedFilesError && <Alert>An error occurred: {fetchedFilesError}. Cannot load files from the server.</Alert>}
+                {fetchedMetadataError && <Alert>An error occurred: {fetchedMetadataError}. Cannot load metadata from the server.</Alert>}
+                {/*@formatter:on*/}
 
                 <form>
                     <Card title="Upload your data" defaultOpened>
@@ -245,9 +207,12 @@ class DepositForm extends Component<DepositFormProps> {
                         </Loaded>
                     </Card>
 
-                    <SaveDraftError saveError={saveError}/>
-                    <SubmitError submitError={submitError}/>
-                    {this.props.submitFailed && this.props.invalid && <ValidationError/>}
+                    {/*@formatter:off*/}
+                    {saveError && <Alert>An error occurred: {saveError}. Cannot save the draft of this deposit.</Alert>}
+                    {submitError && <Alert>An error occurred: {submitError}. Cannot submit this deposit.</Alert>}
+                    {this.props.submitFailed && this.props.invalid &&
+                    <Alert key="submitError">Cannot submit this deposit. Some fields are not filled in correctly.</Alert>}
+                    {/*@formatter:on*/}
 
                     <div className="buttons">
                         <button type="button"

--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -133,6 +133,10 @@ class DepositForm extends Component<DepositFormProps> {
             window.onbeforeunload = null
     }
 
+    componentWillUnmount() {
+        window.onbeforeunload = null
+    }
+
     render() {
         const { fetching: fetchingMetadata, fetched: fetchedMetadata, fetchError: fetchedMetadataError } = this.props.formState.fetchMetadata
         const { loading: fetchingFiles, loaded: fetchedFiles, loadingError: fetchedFilesError } = this.props.fileState

--- a/src/main/typescript/constants/clientRoutes.ts
+++ b/src/main/typescript/constants/clientRoutes.ts
@@ -18,5 +18,6 @@ import { contextRoot } from "../lib/config"
 
 export const homeRoute = contextRoot === "" ? "/" : contextRoot
 export const loginRoute = `${contextRoot}/login`
+export const signoutRoute = `${contextRoot}/signout`
 export const depositFormRoute = (id: DepositId) => `${contextRoot}/deposit-form/${id}`
 export const depositOverviewRoute = `${contextRoot}/deposit-overview`


### PR DESCRIPTION
Fixes EASY-2087

#### When applied it will
* make some errors on the deposit form more specific (_not related to the actual issue_)
* implement signout routing as an alternative to 'onClick' after a 'Prompt OK'

@DANS-KNAW/easy for review

#### Explanation of the bug and the chosen solution
The `<Prompt/>` that causes the warning about an unsaved form blocks the routing that is done via react-router, but does not prevent an `onClick` event on the `<Link/>` (in the header) from happening, as we currently do in the `<Header/>` component. Instead, the `log out` link now goes to a different page, that does the `signout` procedure with the server and then reroutes to 'home', as the original `<Link/>` did.