### PR TITLE
EASY-2106: deposit-overview page numbers can take non-integer values

### DIFF
--- a/src/main/typescript/components/Paginationable.tsx
+++ b/src/main/typescript/components/Paginationable.tsx
@@ -63,20 +63,6 @@ function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntrie
             nextPage()
     })
 
-    const renderShowEntriesDropdown = () => (
-        <label className="mb-2">
-            {"Show "}
-            <select value={entriesPerPage} onChange={onSelectEntriesPerPage}>
-                <option value={10}>10</option>
-                <option value={25}>25</option>
-                <option value={50}>50</option>
-                <option value={100}>100</option>
-                <option value={200}>200</option>
-            </select>
-            {` ${entryDescription}`}
-        </label>
-    )
-
     const renderShowingCount = () => {
         const startIndex = currentStartIndex + 1
 
@@ -115,7 +101,17 @@ function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntrie
 
     return (
         <div>
-            {renderShowEntriesDropdown()}
+            <label className="mb-2">
+                {"Show "}
+                <select value={entriesPerPage} onChange={onSelectEntriesPerPage}>
+                    <option value={10}>10</option>
+                    <option value={25}>25</option>
+                    <option value={50}>50</option>
+                    <option value={100}>100</option>
+                    <option value={200}>200</option>
+                </select>
+                {` ${entryDescription}`}
+            </label>
             {renderEntries(entriesToBeRendered, entryCount)}
             <div className="row ml-0 mr-0 paginationable_bottom">
                 <div className="col-12 col-sm-6 col-md-5 pl-3 show_entry_count_column">

--- a/src/main/typescript/components/Paginationable.tsx
+++ b/src/main/typescript/components/Paginationable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react"
-import { useEffect, useState } from "react"
+import { ChangeEvent, useEffect, useState } from "react"
 import { range } from "lodash"
 import "../../resources/css/paginationable.css"
 
@@ -50,6 +50,11 @@ function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntrie
 
         return range(start, end, 1)
     }
+    const onSelectEntriesPerPage: (e: ChangeEvent<HTMLSelectElement>) => void = event => {
+        const newEntriesPerPage = Number(event.target.value)
+        setEntriesPerPage(newEntriesPerPage)
+        setCurrentStartIndex(Math.floor(currentStartIndex / newEntriesPerPage) * newEntriesPerPage)
+    }
 
     useEffect(() => {
         if (currentStartIndex >= entryCount)
@@ -61,7 +66,7 @@ function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntrie
     const renderShowEntriesDropdown = () => (
         <label className="mb-2">
             {"Show "}
-            <select value={entriesPerPage} onChange={event => setEntriesPerPage(Number(event.target.value))}>
+            <select value={entriesPerPage} onChange={onSelectEntriesPerPage}>
                 <option value={10}>10</option>
                 <option value={25}>25</option>
                 <option value={50}>50</option>

--- a/src/main/typescript/components/Paginationable.tsx
+++ b/src/main/typescript/components/Paginationable.tsx
@@ -63,12 +63,6 @@ function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntrie
             nextPage()
     })
 
-    const renderShowingCount = () => {
-        const startIndex = currentStartIndex + 1
-
-        return `Showing ${startIndex} to ${currentEndIndex} of ${entryCount} ${entryDescription}`
-    }
-
     const renderPagination = () => (
         <nav>
             <ul className="pagination justify-content-end mb-0">
@@ -115,7 +109,7 @@ function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntrie
             {renderEntries(entriesToBeRendered, entryCount)}
             <div className="row ml-0 mr-0 paginationable_bottom">
                 <div className="col-12 col-sm-6 col-md-5 pl-3 show_entry_count_column">
-                    {entryCount > 0 && renderShowingCount()}
+                    {entryCount > 0 && `Showing ${currentStartIndex + 1} to ${currentEndIndex} of ${entryCount} ${entryDescription}`}
                 </div>
                 <div className="col-12 col-sm-6 col-md-7 pl-3 pr-sm-0 pr-md-3">
                     {maxPage > 1 && renderPagination()}

--- a/src/main/typescript/components/Paginationable.tsx
+++ b/src/main/typescript/components/Paginationable.tsx
@@ -31,7 +31,7 @@ function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntrie
 
     const entriesToBeRendered = entries.slice(currentStartIndex, currentStartIndex + entriesPerPage) // end index is exclusive
     const entryCount = entries.length
-    const currentEndIndex = Math.min(entryCount, currentStartIndex + entriesPerPage)
+    const currentEndIndex = Math.min(entryCount, currentStartIndex + entriesPerPage) - 1
     const hasNextPage = currentStartIndex + entriesPerPage < entryCount
     const hasPreviousPage = currentStartIndex - entriesPerPage >= 0
     const maxPage = Math.ceil(entryCount / entriesPerPage)
@@ -109,7 +109,7 @@ function Paginationable<T>({ entryDescription, pagesShown, entries, renderEntrie
             {renderEntries(entriesToBeRendered, entryCount)}
             <div className="row ml-0 mr-0 paginationable_bottom">
                 <div className="col-12 col-sm-6 col-md-5 pl-3 show_entry_count_column">
-                    {entryCount > 0 && `Showing ${currentStartIndex + 1} to ${currentEndIndex} of ${entryCount} ${entryDescription}`}
+                    {entryCount > 0 && `Showing ${currentStartIndex + 1} to ${currentEndIndex + 1} of ${entryCount} ${entryDescription}`}
                 </div>
                 <div className="col-12 col-sm-6 col-md-7 pl-3 pr-sm-0 pr-md-3">
                     {maxPage > 1 && renderPagination()}


### PR DESCRIPTION
Fixes EASY-2106

#### When applied it will
* recalculate the start index on change in `entriesPerPage`
* some refactorings and inlining

@DANS-KNAW/easy for review
@rkruithof I could not reproduce the decimal number examples you showed in the issue, but I fixed the `startIndex` recalculation. Example:

In the tables below we go from `old state` (10 elements per page) to `new state` (20 elements per page). If you go from `old state` page 1, to `new state`, we want to end up on page 0. `old state` page 5 ends up in `new state` on page 2. etcetera...

`elements per page = 10 (old state)`

page number | start index | end index
-------------:|-----------:|---------:
0 | 0 | 9
1 | 10 | 19
2 | 20 | 29
3 | 30 | 39
4 | 40 | 49
5 | 50 | 59
6 | 60 | 69
7 | 70 | 79

`elements per page = 20 (new state)`

page number | start index | end index
-------------:|-----------:|---------:
0 | 0 | 19
1 | 20 | 39
2 | 40 | 59
3 | 60 | 79