### PR TITLE
EASY-2098: newline wrapping of deposit overview state description

### DIFF
--- a/src/main/resources/css/depositOverviewPage.css
+++ b/src/main/resources/css/depositOverviewPage.css
@@ -96,6 +96,10 @@
     visibility: hidden;
 }
 
+.deposit_table tbody tr td.newline-wrapping {
+    white-space: pre-wrap;
+}
+
 @media (max-width: 767px) {
     .deposit_table thead {
         display: none;

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -87,7 +87,7 @@ const DepositTableRow = ({ deposit, deleting, editable, depositLink, deleteDepos
             <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3">
                 <Linkable enabled={!isDeleting && editable} to={depositLink}>{deposit.state}</Linkable>
             </td>
-            <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4">
+            <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4 newline-wrapping">
                 <Linkable enabled={!isDeleting && editable} to={depositLink}>{deposit.stateDescription}</Linkable>
             </td>
             <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5" id="actions_cell">

--- a/src/test/typescript/mockserver/deposit.ts
+++ b/src/test/typescript/mockserver/deposit.ts
@@ -40,7 +40,11 @@ export const depositData2: Deposit = {
 export const depositData3: Deposit = {
     title: "First Dataset",
     state: "IN_PROGRESS",
-    stateDescription: "",
+    stateDescription: "Update request for solr4files index service failed: 2 exceptions occurred: \n" +
+        "--- START OF EXCEPTION LIST ---\n" +
+        "(0) Server refused connection at: http://localhost:8983/solr/fileitems\n" +
+        "(1) solr update of file 1bebc9ef-bb5b-4fc5-943c-396a4e1ae7af/data/xxx/yyy/zzz.pdf failed with Server refused connection at: http://localhost:8983/solr/fileitems\n" +
+        "--- END OF EXCEPTION LIST ---.",
     date: "2017-12-01T11:10:22Z",
 }
 export const depositData4: Deposit = {


### PR DESCRIPTION
Fixes EASY-2098

#### When applied it will
* render newlines in the deposit overview state description

@DANS-KNAW/easy for review

**before:**
![image](https://user-images.githubusercontent.com/5938204/58697076-31c8f800-8399-11e9-8867-43ef5851a9c7.png)

**after:**
![image](https://user-images.githubusercontent.com/5938204/58697058-2970bd00-8399-11e9-9fbd-1cced9e053f2.png)