### PR TITLE
make <a/> tags in deposit description clickable

### DIFF
--- a/src/main/resources/css/depositOverviewPage.css
+++ b/src/main/resources/css/depositOverviewPage.css
@@ -92,6 +92,11 @@
     cursor: not-allowed;
 }
 
+.deposit_table tbody tr.not_editable_table_row a {
+    color: var(--table-row-disabled);
+    cursor: pointer;
+}
+
 .deposit_table tbody tr.not_editable_table_row #enter_dataset {
     visibility: hidden;
 }

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -72,26 +72,29 @@ const DepositTableRow = ({ deposit, deleting, editable, depositLink, deleteDepos
             </button>
         </div>
 
+    const enabled = !isDeleting && editable
     const rowStyling = isDeleting ? "" : editable ? "editable_table_row" : "not_editable_table_row"
 
     return (
         <tr className={["row ml-0 mr-0", rowStyling].join(" ")}>
             {/* these column sizes need to match with the sizes in DepositTableHead */}
             <td className="col col-10 order-1 col-sm-11 order-sm-1 col-md-3 order-md-1" scope="row">
-                <Linkable enabled={!isDeleting && editable} to={depositLink}>{title}</Linkable>
+                <Linkable enabled={enabled} to={depositLink}>{title}</Linkable>
                 {confirmButtons}
             </td>
             <td className="col col-12 order-3 col-sm-12 order-sm-3 col-md-2 order-md-2">
-                <Linkable enabled={!isDeleting && editable} to={depositLink}>{dateFormat(deposit.date)}</Linkable>
+                <Linkable enabled={enabled} to={depositLink}>{dateFormat(deposit.date)}</Linkable>
             </td>
             <td className="col col-12 order-4 col-sm-12 order-sm-4 col-md-2 order-md-3">
-                <Linkable enabled={!isDeleting && editable} to={depositLink}>{deposit.state}</Linkable>
+                <Linkable enabled={enabled} to={depositLink}>{deposit.state}</Linkable>
             </td>
             <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4 newline-wrapping">
-                <Linkable enabled={!isDeleting && editable} to={depositLink}>{deposit.stateDescription}</Linkable>
+                <Linkable enabled={enabled} to={depositLink}>
+                    <span dangerouslySetInnerHTML={{__html: deposit.stateDescription}}/>
+                </Linkable>
             </td>
             <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5" id="actions_cell">
-                <Linkable enabled={!isDeleting && editable} to={depositLink}/>
+                <Linkable enabled={enabled} to={depositLink}/>
                 {deleteButton}
             </td>
         </tr>

--- a/src/main/typescript/components/overview/DepositTableRow.tsx
+++ b/src/main/typescript/components/overview/DepositTableRow.tsx
@@ -31,7 +31,7 @@ interface LinkableProps {
     enabled: boolean
 }
 
-const Linkable: FC<LinkableProps & LinkProps> = ({to, enabled, children}) => {
+const Linkable: FC<LinkableProps & LinkProps> = ({ to, enabled, children }) => {
     return enabled
         ? <Link to={to}>{children}</Link>
         : <>{children}</>
@@ -90,7 +90,7 @@ const DepositTableRow = ({ deposit, deleting, editable, depositLink, deleteDepos
             </td>
             <td className="col col-12 order-5 col-sm-12 order-sm-5 col-md-4 order-md-4 newline-wrapping">
                 <Linkable enabled={enabled} to={depositLink}>
-                    <span dangerouslySetInnerHTML={{__html: deposit.stateDescription}}/>
+                    <span dangerouslySetInnerHTML={{ __html: deposit.stateDescription }}/>
                 </Linkable>
             </td>
             <td className="col col-2  order-2 col-sm-1  order-sm-2 col-md-1 order-md-5" id="actions_cell">

--- a/src/test/typescript/mockserver/deposit.ts
+++ b/src/test/typescript/mockserver/deposit.ts
@@ -42,8 +42,8 @@ export const depositData3: Deposit = {
     state: "IN_PROGRESS",
     stateDescription: "Update request for solr4files index service failed: 2 exceptions occurred: \n" +
         "--- START OF EXCEPTION LIST ---\n" +
-        "(0) Server refused connection at: http://localhost:8983/solr/fileitems\n" +
-        "(1) solr update of file 1bebc9ef-bb5b-4fc5-943c-396a4e1ae7af/data/xxx/yyy/zzz.pdf failed with Server refused connection at: http://localhost:8983/solr/fileitems\n" +
+        "(0) Server refused connection at: <a href='http://localhost:8983/solr/fileitems' target='_blank'>http://localhost:8983/solr/fileitems</a>\n" +
+        "(1) solr update of file 1bebc9ef-bb5b-4fc5-943c-396a4e1ae7af/data/xxx/yyy/zzz.pdf failed with Server refused connection at: <a href='http://localhost:8983/solr/fileitems' target='_blank'>http://localhost:8983/solr/fileitems</a>\n" +
         "--- END OF EXCEPTION LIST ---.",
     date: "2017-12-01T11:10:22Z",
 }


### PR DESCRIPTION
#### When applied it will
* render deposit descriptions with HTML tags as such; concretely renders `<a/>` tags properly and makes them clickable

@DANS-KNAW/easy for review

#### See also
* https://github.com/DANS-KNAW/easy-deposit-api/pull/164
* https://github.com/DANS-KNAW/easy-deposit-api/pull/161/files?file-filters%5B%5D=.properties&file-filters%5B%5D=.scala#r296196986