### PR TITLE
EASY-2135: connection between access right and personal data field

### DIFF
--- a/src/main/resources/css/helptext.css
+++ b/src/main/resources/css/helptext.css
@@ -46,6 +46,10 @@
     padding-right: 10px;
 }
 
+.help-text p {
+    margin-bottom: .5rem;
+}
+
 .help-text p:last-child,
 .help-text ul:last-child {
     margin: unset;

--- a/src/main/resources/helptexts/privacySensitiveDataPresent.html
+++ b/src/main/resources/helptexts/privacySensitiveDataPresent.html
@@ -5,3 +5,6 @@
     an identification number, location data, an online identifier or to one or more factors
     specific to the physical, physiological, genetic, mental, economic, cultural or social
     identity of that natural person." This includes pseudonymised data.</p>
+<p>If your data or metadata contain personal data, access to the dataset is automatically
+    restricted and the DANS usage licence is automatically attached to it. If it doesn’t
+    contain personal data, it is by default Open Access and you can select a usage licence.</p>

--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -148,6 +148,12 @@ const DepositForm = (props: DepositFormProps) => {
                     </Loaded>
                 </Card>
 
+                <Card title="Personal data" required defaultOpened>
+                    <Loaded loading={fetchingMetadata} loaded={fetchedMetadata} error={fetchedMetadataError}>
+                        <PrivacySensitiveDataForm/>
+                    </Loaded>
+                </Card>
+
                 <Card title="Basic information" required defaultOpened>
                     <Loaded loading={fetchingMetadata} loaded={fetchedMetadata} error={fetchedMetadataError}>
                         <BasicInformationForm depositId={depositId}/>
@@ -181,12 +187,6 @@ const DepositForm = (props: DepositFormProps) => {
                 <Card title="Message for the data manager">
                     <Loaded loading={fetchingMetadata} loaded={fetchedMetadata} error={fetchedMetadataError}>
                         <MessageForDataManagerForm/>
-                    </Loaded>
-                </Card>
-
-                <Card title="Personal data" required defaultOpened>
-                    <Loaded loading={fetchingMetadata} loaded={fetchedMetadata} error={fetchedMetadataError}>
-                        <PrivacySensitiveDataForm/>
                     </Loaded>
                 </Card>
 

--- a/src/main/typescript/components/form/parts/LicenseAndAccessForm.tsx
+++ b/src/main/typescript/components/form/parts/LicenseAndAccessForm.tsx
@@ -16,7 +16,7 @@
 import * as React from "react"
 import TextFieldArray from "../../../lib/formComponents/TextFieldArray"
 import { RepeatableField, RepeatableFieldWithDropdown } from "../../../lib/formComponents/ReduxFormUtils"
-import { Field, Fields } from "redux-form"
+import { Field } from "redux-form"
 import { Contributor, emptyRightsholder } from "../../../lib/metadata/Contributor"
 import { AccessRight } from "../../../lib/metadata/AccessRight"
 import { emptyString } from "../../../lib/metadata/misc"
@@ -59,9 +59,7 @@ const LicenseAndAccessForm = () => (
                          fieldNames={[(name: string) => name]}
                          component={TextFieldArray}/>
 
-        <Fields names={["accessRights", "license"]}
-                dropDown={{ licenses: useSelector(state => state.dropDowns.licenses) }}
-                component={AccessRightsAndLicenseFields}/>
+        <AccessRightsAndLicenseFields licenseDropdown={useSelector(state => state.dropDowns.licenses)}/>
 
         <Field name="dateAvailable"
                label="Date available"

--- a/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
+++ b/src/main/typescript/components/form/parts/licenseAndAccess/AccessRightsField.tsx
@@ -16,40 +16,27 @@
 import * as React from "react"
 import { ChangeEvent } from "react"
 import { EventWithDataHandler, Field } from "redux-form"
-import { AccessRightValue } from "../../../../lib/metadata/AccessRight"
 import asField, { InnerComponentProps } from "../../../../lib/formComponents/FieldHOC"
-import { RadioChoicesInput } from "../../../../lib/formComponents/RadioChoices"
+import { RadioChoice, RadioChoicesInput } from "../../../../lib/formComponents/RadioChoices"
 import { FieldProps } from "../../../../lib/formComponents/ReduxFormUtils"
 
 interface AccessRightsFieldOwnProps {
+    choices: RadioChoice[]
     onAccessRightChange: EventWithDataHandler<ChangeEvent<any>>
 }
 
 type AccessRightsFieldProps = FieldProps & InnerComponentProps & AccessRightsFieldOwnProps
 
-const AccessRightsField = ({ input, className, onAccessRightChange }: AccessRightsFieldProps) => {
-    const choices = [
-        {
-            title: AccessRightValue.OPEN_ACCESS,
-            value: "Open Access",
-        },
-        {
-            title: AccessRightValue.REQUEST_PERMISSION,
-            value: "Restricted Access",
-        },
-    ]
-
-    return (
-        <div className={`form-row accessrights-field ${className || ""}`}>
-            <div className="col col-md-4 category-field">
-                <Field name={`${input.name}.category`}
-                       divClassName="radio-button"
-                       choices={choices}
-                       onChange={onAccessRightChange}
-                       component={RadioChoicesInput}/>
-            </div>
+const AccessRightsField = ({ input, className, choices, onAccessRightChange }: AccessRightsFieldProps) => (
+    <div className={`form-row accessrights-field ${className || ""}`}>
+        <div className="col col-md-4 category-field">
+            <Field name={`${input.name}.category`}
+                   divClassName="radio-button"
+                   choices={choices}
+                   onChange={onAccessRightChange}
+                   component={RadioChoicesInput}/>
         </div>
-    )
-}
+    </div>
+)
 
 export default asField(AccessRightsField)

--- a/src/main/typescript/lib/formComponents/RadioChoices.tsx
+++ b/src/main/typescript/lib/formComponents/RadioChoices.tsx
@@ -21,6 +21,7 @@ export interface RadioChoice {
     name?: string
     title: any
     value: string | JSX.Element
+    disabled?: () => boolean
 }
 
 export interface RadioProps {
@@ -30,7 +31,7 @@ export interface RadioProps {
 
 const RadioChoices = ({ input, choices, divClassName }: FieldProps & RadioProps) => (
     <>
-        {choices.map(({ name, title, value }) =>
+        {choices.map(({ name, title, value, disabled }) =>
             <div className={`form-check col-12 ${divClassName || ""}`}
                  key={name || title.toString()}>
                 {/*
@@ -38,7 +39,8 @@ const RadioChoices = ({ input, choices, divClassName }: FieldProps & RadioProps)
                   * {...input} must come before value={title} and neither of them may be omitted.
                   */}
                 <input className="form-check-input" id={name || title.toString()} type="radio"
-                       {...input} value={title} checked={input.value === title.toString()}/>
+                       {...input} value={title} checked={input.value === title.toString()}
+                       disabled={disabled && disabled()}/>
                 <label className="form-check-label" htmlFor={name || title.toString()}>{value}</label>
             </div>,
         )}

--- a/src/main/typescript/lib/metadata/Metadata.ts
+++ b/src/main/typescript/lib/metadata/Metadata.ts
@@ -22,7 +22,7 @@ import {
     languageOfFilesIsoDeconverter,
     languagesOfFilesConverter,
 } from "./Language"
-import { accessRightConverter, accessRightDeconverter } from "./AccessRight"
+import { accessRightConverter, accessRightDeconverter, AccessRightValue } from "./AccessRight"
 import {
     availableQualifier,
     createdQualifier,
@@ -103,7 +103,7 @@ export const metadataConverter: (input: any, dropDowns: DropdownLists) => Deposi
     const instructionsForReuse = input.instructionsForReuse && input.instructionsForReuse.join("\n\n")
     const accessRights = input.accessRights
         ? accessRightConverter(input.accessRights)
-        : { category: undefined }
+        : { category: AccessRightValue.OPEN_ACCESS }
     const license = input.license
         ? licenseConverter(dropDowns.licenses.list)(input.license)
         : emptyLicense

--- a/src/test/typescript/lib/metadata/Metadata.spec.ts
+++ b/src/test/typescript/lib/metadata/Metadata.spec.ts
@@ -77,6 +77,6 @@ describe("Metadata", () => {
         const converted = metadataConverter(input, dropdownLists)
         const deconverted = metadataDeconverter(converted, dropdownLists, false)
 
-        expect(deconverted).to.eql(input)
+        expect(deconverted).to.eql({ accessRights: "OPEN_ACCESS", ...newMetadata() })
     })
 })


### PR DESCRIPTION
Fixes EASY-2135

#### When applied it will
* Move the 'Personal data' card up to the top of the metadata cards
* When `Yes, this dataset does contain personal data` is clicked:
    * Access right option `Open Access` will be disabled
    * Access right option `Restricted Access` will be selected
    * License `DANS LICENSE` will be selected
* When `No, this dataset does not contain personal data` is clicked:
    * Access right option `Open Access` will be selected (and re-enabled if it was disabled before)
    * No license will yet be selected by default; the user can decide on the license on its own
* [x] @lindareijnhoudt in the issue you say: "_de default moet dus Open Access zijn (bij een nieuwe deposit)_". Does this mean that `Open Access` should be selected by default when a new deposit is created?
    * _After discussion with Marjan, this turned out to be the case. I added the default in fa1a23b._
* [x] The issue says: "_de helptekst bovenin het 'persoondata' blokje zal dit duidelijk (gaan) moeten maken_". This is not yet done. I'll discuss this with Marjan.
    * _Discussed this with Marjan. She sent me a new version of this help text, which was added in 15a812d._

@DANS-KNAW/easy for review

_New location for the 'Personal data' card:_
![image](https://user-images.githubusercontent.com/5938204/60589894-dd9ba400-9d9a-11e9-9bdd-97232cf3ef8a.png)

_Select `yes` for 'personal data'_
![image](https://user-images.githubusercontent.com/5938204/60589991-26ebf380-9d9b-11e9-8b09-0e3691e5fd5c.png)

_Select `no` for 'personal data'_
![image](https://user-images.githubusercontent.com/5938204/60590108-6e727f80-9d9b-11e9-8e3a-0cc66de0a866.png)