### PR TITLE
EASY-2250: don't split description, source and instructionsForReuse on newlines

### DIFF
--- a/src/main/typescript/lib/metadata/Metadata.ts
+++ b/src/main/typescript/lib/metadata/Metadata.ts
@@ -194,7 +194,7 @@ export const metadataDeconverter: (data: DepositFormMetadata, dropDowns: Dropdow
         languageOfDescription: data.languageOfDescription && languageOfDescriptionDeconverter(dropDowns.languages.list)(data.languageOfDescription),
         titles: data.titles && data.titles.filter(t => !isEmptyString(t)),
         alternativeTitles: data.alternativeTitles && data.alternativeTitles.filter(at => !isEmptyString(at)),
-        descriptions: data.description && data.description.split("\n\n"),
+        descriptions: data.description && [data.description],
         creators: creators.map(creatorDeconverter).filter(nonEmptyObject),
         contributors: [
             ...(contributors ? contributors.map(contributorDeconverter(dropDowns.contributorRoles.list)) : []),
@@ -238,8 +238,8 @@ export const metadataDeconverter: (data: DepositFormMetadata, dropDowns: Dropdow
             ...(data.datesIso8601 ? data.datesIso8601.map(qualifiedDateDeconverter(dropDowns.dates.list)) : []),
             ...(data.dates ? data.dates.map(qualifiedDateStringDeconverter(dropDowns.dates.list)) : []),
         ].filter(nonEmptyObject),
-        sources: data.source && data.source.split("\n\n"),
-        instructionsForReuse: data.instructionsForReuse && data.instructionsForReuse.split("\n\n"),
+        sources: data.source && [data.source],
+        instructionsForReuse: data.instructionsForReuse && [data.instructionsForReuse],
 
         // license and access
         publishers: data.publishers && data.publishers.filter(p => !isEmptyString(p)),

--- a/src/test/typescript/mockserver/metadata.ts
+++ b/src/test/typescript/mockserver/metadata.ts
@@ -280,10 +280,7 @@ export const allfields: Metadata = {
     },
     titles: ["title 1", "title2"],
     alternativeTitles: ["alternative title 1", "alternative title2"],
-    descriptions: [
-        "description1",
-        "description2",
-    ],
+    descriptions: ["description1\n\ndescription2"],
     creators: [
         {
             titles: "Drs.",
@@ -464,14 +461,8 @@ export const allfields: Metadata = {
             qualifier: DateQualifierValues.issued,
         },
     ],
-    sources: [
-        "source1",
-        "source2",
-    ],
-    instructionsForReuse: [
-        "remark1",
-        "remark2",
-    ],
+    sources: ["source1\n\nsource2"],
+    instructionsForReuse: ["remark1\n\nremark2"],
     publishers: [
         "pub1",
         "pub2",
@@ -612,10 +603,7 @@ export const mandatoryOnly: Metadata = {
     titles: [
         "title1",
     ],
-    descriptions: [
-        "description1",
-        "description2",
-    ],
+    descriptions: ["description1\n\ndescription2"],
     creators: [
         {
             initials: "A.S.",


### PR DESCRIPTION
Fixes EASY-2250

#### When applied it will
* no longer split `description`, `source` and `instructionsForReuse` on newlines on save in `deposit-api`

@DANS-KNAW/easy for review