### PR TITLE
EASY-2257 : use display name to show the same value as in webui

### DIFF
--- a/src/main/typescript/components/form/DepositForm.tsx
+++ b/src/main/typescript/components/form/DepositForm.tsx
@@ -96,9 +96,9 @@ const DepositForm = (props: DepositFormProps) => {
      *   1. create a new deposit
      *   2. edit 1 field
      *   3. save the draft
-     *   4. tough a field (NO editting!)
+     *   4. touch a field (NO editing!)
      *   5. on top of the page, click on 'my datasets' to leave the page
-     *   6. while the form was saved and nothing was editted afterwards,
+     *   6. while the form was saved and nothing was edited afterwards,
      *      it still shows a warning saying the user did not save all changes
      */
     const shouldBlockNavigation = () => props.dirty && props.anyTouched && !props.submitSucceeded

--- a/src/main/typescript/lib/user/user.ts
+++ b/src/main/typescript/lib/user/user.ts
@@ -16,11 +16,6 @@
 import { UserDetails } from "../../model/UserDetails"
 
 export const userConverter: (input: any) => UserDetails = input => {
-    const firstName = input.firstName ? `${input.firstName} ` : ""
-    const prefix = input.prefix ? `${input.prefix} ` : ""
-    const lastName = input.lastName || ""
-    const displayName = input.displayName || ""
-
     return {
         username: input.username || "",
         firstName: input.firstName || "",

--- a/src/main/typescript/lib/user/user.ts
+++ b/src/main/typescript/lib/user/user.ts
@@ -19,13 +19,14 @@ export const userConverter: (input: any) => UserDetails = input => {
     const firstName = input.firstName ? `${input.firstName} ` : ""
     const prefix = input.prefix ? `${input.prefix} ` : ""
     const lastName = input.lastName || ""
-    const displayName = `${firstName}${prefix}${lastName}`
+    const displayName = input.displayName || ""
+    const easyDisplayName = input.displayName || ""
 
     return {
         username: input.username || "",
         firstName: input.firstName || "",
         prefix: input.prefix || "",
         lastName: input.lastName || "",
-        displayName: displayName,
+        displayName: input.easyDisplayName || "",
     }
 }

--- a/src/main/typescript/lib/user/user.ts
+++ b/src/main/typescript/lib/user/user.ts
@@ -20,13 +20,12 @@ export const userConverter: (input: any) => UserDetails = input => {
     const prefix = input.prefix ? `${input.prefix} ` : ""
     const lastName = input.lastName || ""
     const displayName = input.displayName || ""
-    const easyDisplayName = input.displayName || ""
 
     return {
         username: input.username || "",
         firstName: input.firstName || "",
         prefix: input.prefix || "",
         lastName: input.lastName || "",
-        displayName: input.easyDisplayName || "",
+        displayName: input.displayName || "",
     }
 }

--- a/src/test/typescript/lib/user/user.spec.ts
+++ b/src/test/typescript/lib/user/user.spec.ts
@@ -28,13 +28,14 @@ describe("user", () => {
                 firstName: "First",
                 prefix: "the",
                 lastName: "Name",
+                displayName: "First a Name",
             }
             const expected: UserDetails = {
                 username: "user001",
                 firstName: "First",
                 prefix: "the",
                 lastName: "Name",
-                displayName: "First the Name",
+                displayName: "First a Name",
             }
 
             expect(userConverter(input)).to.eql(expected)
@@ -64,13 +65,14 @@ describe("user", () => {
                 firstName: "",
                 prefix: "the",
                 lastName: "Name",
+                displayName: "a Name",
             }
             const expected: UserDetails = {
                 username: "user001",
                 firstName: "",
                 prefix: "the",
                 lastName: "Name",
-                displayName: "the Name",
+                displayName: "a Name",
             }
 
             expect(userConverter(input)).to.eql(expected)
@@ -82,6 +84,7 @@ describe("user", () => {
                 firstName: "First",
                 prefix: undefined,
                 lastName: "Name",
+                displayName: "First Name",
             }
             const expected: UserDetails = {
                 username: "user001",
@@ -100,13 +103,14 @@ describe("user", () => {
                 firstName: "First",
                 prefix: "the",
                 lastName: undefined,
+                displayName: "a First",
             }
             const expected: UserDetails = {
                 username: "user001",
                 firstName: "First",
                 prefix: "the",
                 lastName: "",
-                displayName: "First the ",
+                displayName: "a First",
             }
 
             expect(userConverter(input)).to.eql(expected)

--- a/src/test/typescript/mockserver/user.ts
+++ b/src/test/typescript/mockserver/user.ts
@@ -18,6 +18,7 @@ export interface User {
     firstName: string
     prefix?: string
     lastName: string
+    displayName: string
 }
 
 export const User001: User = {
@@ -25,4 +26,5 @@ export const User001: User = {
     firstName: "First",
     prefix: undefined,
     lastName: "Namen",
+    displayName: "Namen",
 }


### PR DESCRIPTION
Fixes EASY-2257 : use display name to show the same value as in webui

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* don't use users predefined with dtap: create a new user on the easy-webui of deasy
* login, not the user name in the toolbar
* go to deposits
* the toolbar should show the same user name
* use variations with and without initials
* use ldap (apache directory studia) for variations with/without givenName and/or initials

#### Related pull requests on github
https://github.com/DANS-KNAW/easy-deposit-api/pull/172 should be merged/deployed first
