### PR TITLE
EASY-1975: add configuration.json back into the build output

### DIFF
--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -61,6 +61,7 @@ module.exports = (env, argv) => ({
                 type: "javascript/auto",
                 test: /\.(json)$/i,
                 include: [
+                    path.resolve(process.cwd(), 'src/main/resources/application.json'),
                     path.resolve(process.cwd(), 'src/main/resources/constants/'),
                     path.resolve(process.cwd(), 'target/easy-licenses/licenses/licenses.json'),
                 ],


### PR DESCRIPTION
Fixes EASY-1975

#### When applied it will
* add configuration.json back into the build output

@DANS-KNAW/easy for review