### PR TITLE
EASY-2431 easy-deposit-ui RPM-build faalt met rpm versie 4.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,9 @@
                                     </sources>
                                 </mapping>
                             </mappings>
+                            <defineStatements>
+                                <defineStatement>_invalid_encoding_terminates_build 0</defineStatement>
+                            </defineStatements>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Fixes EASY-2431

#### When applied it will
* Turn on an rpm switch that makes malencoded metadata a warning instead of an error.
* For details see: https://github.com/rpm-software-management/rpm/issues/952#issuecomment-558618524

#### Where should the reviewer @DANS-KNAW/easy start?
