### PR TITLE
EASY-2430: only allow http(s) URLs in relation field

### DIFF
--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -279,7 +279,7 @@ export const validateRelations: (relations: Relation[]) => Relation[] = relation
         else if (!nonEmptyTitle && nonEmptyUrl)
             relationError.title = "No title given"
 
-        if (nonEmptyUrl && !validUrl.isUri(relation.url))
+        if (nonEmptyUrl && !validUrl.isWebUri(relation.url))
             relationError.url = "No valid url given"
 
         return relationError

--- a/src/main/typescript/lib/formComponents/RelationFieldArrayElement.tsx
+++ b/src/main/typescript/lib/formComponents/RelationFieldArrayElement.tsx
@@ -27,7 +27,7 @@ interface RelationValidateButtonProps {
 }
 
 const RelationValidateButton = ({ value }: RelationValidateButtonProps) => (
-    value && validUrl.isUri(value)
+    value && validUrl.isWebUri(value)
         ? <a className="btn btn-dark value-button relation-validate-button"
              href={value}
              target="_blank">

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -553,6 +553,22 @@ describe("Validation", () => {
             }])).to.eql([{ url: "No valid url given" }])
         })
 
+        it("should return an error object when one Relation is given with a 'javascript url'", () => {
+            expect(validateRelations([{
+                qualifier: "q",
+                title: "t",
+                url: "javascript:alert('XSS')",
+            }])).to.eql([{ url: "No valid url given" }])
+        })
+
+        it("should return an error object when one Relation is given with a 'ftp url'", () => {
+            expect(validateRelations([{
+                qualifier: "q",
+                title: "t",
+                url: "ftp://ftp.funet.fi/pub/standards/RFC/rfc959.txt",
+            }])).to.eql([{ url: "No valid url given" }])
+        })
+
         it("should return error objects when multiple (some incomplete) Relations are given", () => {
             expect(validateRelations([
                 {


### PR DESCRIPTION
Fixes EASY-2430

#### When applied it will
* only allow http(s) URLs in relation field

@DANS-KNAW/easy for review