### PR TITLE
EASY-2489: make scheme on related identifier optional

### DIFF
--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -217,13 +217,10 @@ export const validateSchemedValue: (schemedValues: SchemedValue[]) => SchemedVal
 
 export const validateQualifiedSchemedValues: (qsvs: QualifiedSchemedValue[]) => QualifiedSchemedValue[] = qsvs => {
     function validateQualifiedSchemedValue(qsv: QualifiedSchemedValue): QualifiedSchemedValue {
-        const nonEmptyScheme = checkNonEmpty(qsv.scheme)
         const nonEmptyValue = checkNonEmpty(qsv.value)
 
         const relatedIdentifierError: QualifiedSchemedValue = {}
 
-        if (!nonEmptyScheme)
-            relatedIdentifierError.scheme = "No scheme given"
         if (!nonEmptyValue)
             relatedIdentifierError.value = "No identifier given"
 

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -388,7 +388,7 @@ describe("Validation", () => {
             expect(validateQualifiedSchemedValues([{ qualifier: "q", scheme: "s", value: "v" }])).to.eql([{}])
         })
 
-        it("should return an emty object when one QualifiedSchemedValue is given with 'scheme' missing", () => {
+        it("should return an empty object when one QualifiedSchemedValue is given with 'scheme' missing", () => {
             expect(validateQualifiedSchemedValues([{
                 qualifier: "q",
                 // no scheme
@@ -433,7 +433,6 @@ describe("Validation", () => {
                     value: "No identifier given",
                 },
                 {
-                    // scheme: "No scheme given",
                     value: "No identifier given",
                 },
             ])

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -388,12 +388,12 @@ describe("Validation", () => {
             expect(validateQualifiedSchemedValues([{ qualifier: "q", scheme: "s", value: "v" }])).to.eql([{}])
         })
 
-        it("should return an error object when one QualifiedSchemedValue is given with 'scheme' missing", () => {
+        it("should return an emty object when one QualifiedSchemedValue is given with 'scheme' missing", () => {
             expect(validateQualifiedSchemedValues([{
                 qualifier: "q",
                 // no scheme
                 value: "v",
-            }])).to.eql([{ scheme: "No scheme given" }])
+            }])).to.eql([{ }])
         })
 
         it("should return an error object when one QualifiedSchemedValue is given with 'value' missing", () => {
@@ -428,14 +428,12 @@ describe("Validation", () => {
                 },
             ])).to.eql([
                 {},
-                {
-                    scheme: "No scheme given",
-                },
+                {},
                 {
                     value: "No identifier given",
                 },
                 {
-                    scheme: "No scheme given",
+                    // scheme: "No scheme given",
                     value: "No identifier given",
                 },
             ])


### PR DESCRIPTION
Fixes EASY-2849

#### When applied it will
* make scheme on related identifier optional

This change causes the 'scheme' in the related identifier to be optional. Not choosing a scheme leads to a `<dcterms:relation>...</dcterms:relation>` field in DDM and a `<emd:relation><dc:relation>...</dc:relation></emd:relation>` field in EMD. It is displayed in EASY as 
![image](https://user-images.githubusercontent.com/5938204/71819685-edb77780-308c-11ea-8aa7-9bc92f36fdaa.png)

@DANS-KNAW/easy for review