### PR TITLE
EASY-2488: extra validation for spatial box values

### DIFF
--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -378,10 +378,10 @@ export function validateSpatialBoxes(spatialCoordinateSettings: SpatialCoordinat
         }
 
         if (!boxError.north && nonEmptyNorth && nonEmptySouth && Number(box.north) <= Number(box.south))
-            boxError.north = `north coordinate must be larger than south coordinate`
+            boxError.north = "north coordinate must be larger than south coordinate"
 
         if (!boxError.east && nonEmptyEast && nonEmptyWest && Number(box.east) <= Number(box.west))
-            boxError.east = `east coordinate must be larger than west coordinate`
+            boxError.east = "east coordinate must be larger than west coordinate"
 
         return boxError
     })

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -377,6 +377,12 @@ export function validateSpatialBoxes(spatialCoordinateSettings: SpatialCoordinat
                 boxError.west = `west coordinate is out of range: [${entry.xMin},${entry.xMax}]`
         }
 
+        if (!boxError.north && nonEmptyNorth && nonEmptySouth && Number(box.north) <= Number(box.south))
+            boxError.north = `north coordinate must be larger than south coordinate`
+
+        if (!boxError.east && nonEmptyEast && nonEmptyWest && Number(box.east) <= Number(box.west))
+            boxError.east = `east coordinate must be larger than west coordinate`
+
         return boxError
     })
 }

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -680,10 +680,10 @@ describe("Validation", () => {
                 {},
                 {
                     scheme: "http://www.opengis.net/def/crs/EPSG/0/28992",
-                    north: "289001",
-                    east: "15",
-                    south: "289002",
-                    west: "52",
+                    north: "289002",
+                    east: "52",
+                    south: "289001",
+                    west: "15",
                 },
             ])).to.eql([{}, {}])
         })
@@ -704,22 +704,28 @@ describe("Validation", () => {
                     south: "",
                     west: "",
                 },
-            ])).to.eql([{ scheme: "No scheme given" }, {
-                north: "No north coordinate given",
-                east: "No east coordinate given",
-                south: "No south coordinate given",
-                west: "No west coordinate given",
-            }])
+            ])).to.eql([
+                {
+                    scheme: "No scheme given",
+                    "east": "east coordinate must be larger than west coordinate",
+                    "north": "north coordinate must be larger than south coordinate",
+                },
+                {
+                    north: "No north coordinate given",
+                    east: "No east coordinate given",
+                    south: "No south coordinate given",
+                    west: "No west coordinate given",
+                }])
         })
 
         it("should return error objects when out-of-range SpatialBox are given", () => {
             expect(validateSpatialBoxes(spatialCoordinatesSettings, [
                 {
                     scheme: "", // no scheme, so no checks on range
-                    north: "12",
-                    east: "15",
-                    south: "26",
-                    west: "52",
+                    north: "26",
+                    east: "52",
+                    south: "12",
+                    west: "15",
                 },
                 {
                     scheme: "http://www.opengis.net/def/crs/EPSG/0/28992", // RD


### PR DESCRIPTION
Fixes EASY-2488

#### When applied it will
* add extra validation for spatial box values: `north` must be greater than `south` and `east` must be greater than `west`

@DANS-KNAW/easy for review