### PR TITLE
EASY-2493: hide 'instructions for reuse' field

### DIFF
--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -238,12 +238,14 @@ const BasicInformationForm = ({ depositId }: BasicInformationFormProps) => {
                    maxRows={15}
                    component={TextArea}/>
 
-            <Field name="instructionsForReuse"
+            {/* TODO this field must be removed from the UI.
+                 To avoid making things more complicated before the release, it is just 'hidden' for now. */}
+            {/*<Field name="instructionsForReuse"
                    label="Instructions for reuse"
                    helpText
                    rows={5}
                    maxRows={15}
-                   component={TextArea}/>
+                   component={TextArea}/>*/}
         </>
     )
 }


### PR DESCRIPTION
Fixes EASY-2493

#### When applied it will
* hide the 'instructions for reuse' field

@DANS-KNAW/easy for review