### PR TITLE
EASY-2533: fix typo in PALEOB --> PALEOLB

### DIFF
--- a/src/main/resources/constants/abrPeriodeTemporals.json
+++ b/src/main/resources/constants/abrPeriodeTemporals.json
@@ -19,7 +19,7 @@
     "title": "Paleolithicum laat A: 35000 - 18000 C14",
     "viewName": "Paleolithicum laat A: 35000 - 18000 C14"
   },
-  "PALEOB": {
+  "PALEOLB": {
     "title": "Paleolithicum laat B: 18000 C14 -8800 vC",
     "viewName": "Paleolithicum laat B: 18000 C14 -8800 vC"
   },


### PR DESCRIPTION
Fixes EASY-2533

#### When applied it will
* fix typo: `PALEOB` to `PALEOLB`

@DANS-KNAW/easy for review