### PR TITLE
EASY-2582: add support for id-type:OTHER related/alternative identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9149,7 +9149,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {

--- a/src/main/resources/constants/identifiers.json
+++ b/src/main/resources/constants/identifiers.json
@@ -22,5 +22,9 @@
   "id-type:NWO-PROJECTNR": {
     "title": "NWO project no.",
     "viewName": "NWO project no."
+  },
+  "id-type:OTHER": {
+    "title": "other",
+    "viewName": "other"
   }
 }

--- a/src/main/typescript/components/form/Validation.ts
+++ b/src/main/typescript/components/form/Validation.ts
@@ -221,6 +221,8 @@ export const validateRelatedIdentifiers: (identifierSettings: IdentifiersDropdow
     function validateQualifiedSchemedValue(qsv: QualifiedSchemedValue): QualifiedSchemedValue {
         const relatedIdentifierError: QualifiedSchemedValue = {}
 
+        if (!checkNonEmpty(qsv.scheme))
+            relatedIdentifierError.scheme = "No scheme given"
         if (!checkNonEmpty(qsv.value))
             relatedIdentifierError.value = "No identifier given"
         else {

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -428,12 +428,12 @@ describe("Validation", () => {
             }])).to.eql([{}])
         })
 
-        it("should return an empty object when one related identifier is given with 'scheme' missing", () => {
+        it("should return an error object when one related identifier is given with 'scheme' missing", () => {
             expect(validateRelatedIdentifiers(identifierSettings, [{
                 qualifier: "q",
                 // no scheme
                 value: "v",
-            }])).to.eql([{}])
+            }])).to.eql([{ scheme: "No scheme given" }])
         })
 
         it("should return an error object when one related identifier is given with 'value' missing", () => {
@@ -504,11 +504,14 @@ describe("Validation", () => {
                 },
             ])).to.eql([
                 {},
-                {},
+                {
+                    scheme: "No scheme given",
+                },
                 {
                     value: "No identifier given",
                 },
                 {
+                    scheme: "No scheme given",
                     value: "No identifier given",
                 },
                 {},


### PR DESCRIPTION
Fixes EASY-2582

#### When applied it will
* add support for `id-type:OTHER` related/alternative identifiers

@DANS-KNAW/easy for review

![image](https://user-images.githubusercontent.com/5938204/74135504-b3da1380-4bec-11ea-8ff9-86e16bd25f29.png)