### PR TITLE
EASY-2582: add support for other related/alternative identifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9149,7 +9149,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {

--- a/src/main/resources/constants/identifiers.json
+++ b/src/main/resources/constants/identifiers.json
@@ -22,5 +22,9 @@
   "id-type:NWO-PROJECTNR": {
     "title": "NWO project no.",
     "viewName": "NWO project no."
+  },
+  "": {
+    "title": "",
+    "viewName": "other"
   }
 }

--- a/src/main/typescript/components/form/parts/BasicInformationForm.tsx
+++ b/src/main/typescript/components/form/parts/BasicInformationForm.tsx
@@ -20,7 +20,7 @@ import { RepeatableField, RepeatableFieldWithDropdown } from "../../../lib/formC
 import TextFieldArray from "../../../lib/formComponents/TextFieldArray"
 import TextArea from "../../../lib/formComponents/TextArea"
 import { DepositId } from "../../../model/Deposits"
-import { Doi } from "../../../lib/metadata/Identifier"
+import { Doi, emptyAlternativeIdentifier } from "../../../lib/metadata/Identifier"
 import {
     emptyQualifiedSchemedValue,
     emptySchemedValue,
@@ -29,7 +29,7 @@ import {
 } from "../../../lib/metadata/Value"
 import { Contributor, emptyContributor } from "../../../lib/metadata/Contributor"
 import { emptyQualifiedDate, emptyQualifiedStringDate, QualifiedDate } from "../../../lib/metadata/Date"
-import { emptyRelation, Relation } from "../../../lib/metadata/Relation"
+import { emptyRelatedIdentifier, emptyRelation, Relation } from "../../../lib/metadata/Relation"
 import { emptyString } from "../../../lib/metadata/misc"
 import AudienceFieldArray from "./basicInformation/AudienceFieldArray"
 import AlternativeIdentifierFieldArray from "./basicInformation/AlternativeIdentifierFieldArray"
@@ -159,7 +159,7 @@ const BasicInformationForm = ({ depositId }: BasicInformationFormProps) => {
             <RepeatableFieldWithDropdown name="alternativeIdentifiers"
                                          label="Alternative identifier"
                                          helpText
-                                         empty={() => emptySchemedValue}
+                                         empty={() => emptyAlternativeIdentifier(identifiers.list)}
                                          fieldNames={[
                                              (name: string) => `${name}.scheme`,
                                              (name: string) => `${name}.value`,
@@ -170,7 +170,7 @@ const BasicInformationForm = ({ depositId }: BasicInformationFormProps) => {
             <RepeatableFieldWithDropdown name="relatedIdentifiers"
                                          label="Related identifier"
                                          helpText
-                                         empty={() => emptyQualifiedSchemedValue(relations.list)}
+                                         empty={() => emptyRelatedIdentifier(relations.list, identifiers.list)}
                                          fieldNames={[
                                              (name: string) => `${name}.qualifier`,
                                              (name: string) => `${name}.scheme`,

--- a/src/main/typescript/components/form/parts/basicInformation/AlternativeIdentifierFieldArray.tsx
+++ b/src/main/typescript/components/form/parts/basicInformation/AlternativeIdentifierFieldArray.tsx
@@ -22,7 +22,7 @@ import { DropdownList } from "../../../../model/DropdownLists"
 
 const AlternativeIdentifierFieldArray = ({ dropdowns: { schemes }, ...props }: FieldArrayPropsWithDropdown<SchemedValue, DropdownList>) => (
     <LoadDropdownData state={schemes.state}>
-        <SchemedTextFieldArray {...props} withEmptyDefault schemeValues={schemes.list}/>
+        <SchemedTextFieldArray {...props} schemeValues={schemes.list}/>
     </LoadDropdownData>
 )
 

--- a/src/main/typescript/components/form/parts/basicInformation/RelatedIdentifierFieldArray.tsx
+++ b/src/main/typescript/components/form/parts/basicInformation/RelatedIdentifierFieldArray.tsx
@@ -25,8 +25,7 @@ const RelatedIdentifierFieldArray = ({ dropdowns: { qualifiers, schemes }, ...pr
         <LoadDropdownData state={schemes.state}>
             <QualifiedSchemedTextFieldArray {...props}
                                             qualifierValues={qualifiers.list}
-                                            schemeValues={schemes.list}
-                                            withEmptySchemeDefault/>
+                                            schemeValues={schemes.list}/>
         </LoadDropdownData>
     </LoadDropdownData>
 )

--- a/src/main/typescript/lib/metadata/Identifier.ts
+++ b/src/main/typescript/lib/metadata/Identifier.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SchemedValue, schemedValueConverter, schemedValueDeconverter } from "./Value"
-import {partition} from "lodash"
+import { emptySchemedValue, SchemedValue, schemedValueConverter, schemedValueDeconverter } from "./Value"
+import { partition } from "lodash"
 import { DropdownListEntry } from "../../model/DropdownLists"
 
 enum IdentifierScheme {
@@ -44,6 +44,11 @@ export const doiConverter: (obj: { [scheme: string]: string }) => Doi = obj => o
 export const doiDeconverter: (d: Doi) => any = d => ({
     scheme: IdentifierScheme.DOI,
     value: d,
+})
+
+export const emptyAlternativeIdentifier: (identifiers: DropdownListEntry[]) => SchemedValue = identifiers => ({
+    ...emptySchemedValue,
+    scheme: identifiers[0].key,
 })
 
 const alternativeIdentifierConverter: (identifiers: DropdownListEntry[]) => (ai: any) => SchemedValue = identifiers => ai => {

--- a/src/main/typescript/lib/metadata/Metadata.ts
+++ b/src/main/typescript/lib/metadata/Metadata.ts
@@ -39,7 +39,7 @@ import {
     alternativeIdentifierDeconverter,
     archisIdentifierDeconverter,
     doiConverter,
-    doiDeconverter,
+    doiDeconverter, emptyAlternativeIdentifier,
     identifiersConverter,
 } from "./Identifier"
 import { dcmiTypeDeconverter, typeDeconverter, typesConverter } from "./Type"
@@ -50,7 +50,13 @@ import {
 } from "./PrivacySensitiveData"
 import { emptyQualifiedSchemedValue, emptySchemedValue } from "./Value"
 import { emptyLicense, licenseConverter, licenseDeconverter } from "./License"
-import { emptyRelation, relatedIdentifierDeconverter, relationDeconverter, relationsConverter } from "./Relation"
+import {
+    emptyRelatedIdentifier,
+    emptyRelation,
+    relatedIdentifierDeconverter,
+    relationDeconverter,
+    relationsConverter,
+} from "./Relation"
 import { clean, emptyString, isEmptyString, nonEmptyObject, normalizeEmpty } from "./misc"
 import { cmdiFormatDeconverter, formatDeconverter, formatsConverter, imtFormatDeconverter } from "./Format"
 import {
@@ -136,8 +142,8 @@ export const metadataConverter: (input: any, dropDowns: DropdownLists) => Deposi
         dateCreated: dateCreated && dateCreated.value,
         audiences: normalizeEmpty(audiences, () => emptyString),
         subjects: normalizeEmpty(subjects, () => emptyString),
-        alternativeIdentifiers: normalizeEmpty(alternativeIdentifiers, () => emptySchemedValue),
-        relatedIdentifiers: normalizeEmpty(relatedIdentifiers, () => emptyQualifiedSchemedValue(dropDowns.relations.list)),
+        alternativeIdentifiers: normalizeEmpty(alternativeIdentifiers, () => emptyAlternativeIdentifier(dropDowns.identifiers.list)),
+        relatedIdentifiers: normalizeEmpty(relatedIdentifiers, () => emptyRelatedIdentifier(dropDowns.relations.list, dropDowns.identifiers.list)),
         relations: normalizeEmpty(relations, () => emptyRelation(dropDowns.relations.list)),
         languagesOfFilesIso639: normalizeEmpty(isoLanguageOfFiles, () => emptyString),
         languagesOfFiles: normalizeEmpty(languageOfFiles, () => emptyString),

--- a/src/main/typescript/lib/metadata/Relation.ts
+++ b/src/main/typescript/lib/metadata/Relation.ts
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { QualifiedSchemedValue, qualifiedSchemedValueConverter, qualifiedSchemedValueDeconverter } from "./Value"
+import {
+    emptyQualifiedSchemedValue,
+    QualifiedSchemedValue,
+    qualifiedSchemedValueConverter,
+    qualifiedSchemedValueDeconverter,
+    SchemedValue,
+} from "./Value"
 import { clean } from "./misc"
 import { DropdownListEntry } from "../../model/DropdownLists"
 
@@ -27,6 +33,11 @@ export const emptyRelation: (qualifiers: DropdownListEntry[]) => Relation = qs =
     qualifier: qs[0].key,
     url: "",
     title: "",
+})
+
+export const emptyRelatedIdentifier: (qualifiers: DropdownListEntry[], identifiers: DropdownListEntry[]) => QualifiedSchemedValue = (qualifiers, identifiers) => ({
+    ...emptyQualifiedSchemedValue(qualifiers),
+    scheme: identifiers[0].key,
 })
 
 const relatedIdentifierConverter: (qualifiers: DropdownListEntry[], identifiers: DropdownListEntry[]) => (ri: any) => QualifiedSchemedValue = (qualifiers, identifiers) => ri => {

--- a/src/main/typescript/lib/metadata/Value.ts
+++ b/src/main/typescript/lib/metadata/Value.ts
@@ -33,10 +33,8 @@ export const schemedValueDeconverter: (sv: SchemedValue) => any = sv => clean({
     value: sv.value,
 })
 
-export interface QualifiedSchemedValue {
+export interface QualifiedSchemedValue extends SchemedValue {
     qualifier?: string
-    scheme?: string
-    value?: string
 }
 
 export const emptyQualifiedSchemedValue: (qualifiers: DropdownListEntry[]) => QualifiedSchemedValue = qs => ({

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -29,7 +29,7 @@ import {
     validateDates,
     validateRelatedIdentifiers,
     validateRelations,
-    validateSchemedValue,
+    validateAlternativeIdentifiers,
     validateSpatialBoxes,
     validateSpatialPoints,
 } from "../../../../main/typescript/components/form/Validation"
@@ -340,40 +340,6 @@ describe("Validation", () => {
         })
     })
 
-    describe("validateSchemedValue", () => {
-        it("should return empty objects when all SchemedValues are valid", () => {
-            expect(validateSchemedValue([
-                {
-                    scheme: "foo",
-                    value: "bar",
-                },
-                {
-                    scheme: "abc",
-                    value: "def",
-                }])).to.eql([{}, {}])
-        })
-
-        it("should return empty objects when the SchemedValues are empty", () => {
-            expect(validateSchemedValue([{ scheme: "", value: "" }, {}])).to.eql([{}, {}])
-        })
-
-        it("should return an empty list when no SchemedValues are given", () => {
-            expect(validateSchemedValue([])).to.eql([])
-        })
-
-        it("should return an error object when only the scheme is given", () => {
-            expect(validateSchemedValue([{ scheme: "foo" }])).to.eql([{
-                value: "No identifier given",
-            }])
-        })
-
-        it("should return an error object when only the value is given", () => {
-            expect(validateSchemedValue([{ value: "bar" }])).to.eql([{
-                scheme: "No scheme given",
-            }])
-        })
-    })
-
     const identifierSettings: IdentifiersDropdownListEntry[] = [
         {
             key: "id-type:DOI",
@@ -404,6 +370,66 @@ describe("Validation", () => {
             displayValue: "NWO project no.",
         },
     ]
+
+    describe("validateAlternativeIdentifiers", () => {
+        it("should return empty objects when all AlternativeIdentifiers are valid", () => {
+            expect(validateAlternativeIdentifiers(identifierSettings, [
+                {
+                    scheme: "foo",
+                    value: "bar",
+                },
+                {
+                    scheme: "abc",
+                    value: "def",
+                }])).to.eql([{}, {}])
+        })
+
+        it("should return empty objects when the AlternativeIdentifiers are empty", () => {
+            expect(validateAlternativeIdentifiers(identifierSettings, [{ scheme: "", value: "" }, {}])).to.eql([{}, {}])
+        })
+
+        it("should return an empty list when no AlternativeIdentifiers are given", () => {
+            expect(validateAlternativeIdentifiers(identifierSettings, [])).to.eql([])
+        })
+
+        it("should return an empty object when only the scheme is given", () => {
+            expect(validateAlternativeIdentifiers(identifierSettings, [{ scheme: "foo" }])).to.eql([{}])
+        })
+
+        it("should return an empty object when only the value is given", () => {
+            expect(validateAlternativeIdentifiers(identifierSettings, [{ value: "bar" }])).to.eql([{}])
+        })
+
+        it("should return error objects when AlternativeIdentifier values don't match the selected schema", () => {
+            expect(validateAlternativeIdentifiers(identifierSettings, [
+                {
+                    scheme: "id-type:DOI",
+                    value: "10.17026/dans-z52-ybfe",
+                },
+                {
+                    scheme: "id-type:URN",
+                    value: "urn:nbn:nl:ui:13-79-7q2b",
+                },
+                {
+                    scheme: "id-type:DOI",
+                    value: "hello world",
+                },
+                {
+                    scheme: "id-type:URN",
+                    value: "hello world",
+                },
+            ])).to.eql([
+                {},
+                {},
+                {
+                    value: "Invalid doi",
+                },
+                {
+                    value: "Invalid urn",
+                },
+            ])
+        })
+    })
 
     describe("validateRelatedIdentifiers", () => {
         it("should return an empty list when no related identifier are given", () => {
@@ -436,12 +462,12 @@ describe("Validation", () => {
             }])).to.eql([{}])
         })
 
-        it("should return an error object when one related identifier is given with 'value' missing", () => {
+        it("should return an empty object when one related identifier is given with 'value' missing", () => {
             expect(validateRelatedIdentifiers(identifierSettings, [{
                 qualifier: "q",
                 scheme: "s",
                 // no value
-            }])).to.eql([{ value: "No identifier given" }])
+            }])).to.eql([{}])
         })
 
         it("should return an error object when one related identifier is given with a value that does not form a valid URL", () => {
@@ -505,12 +531,8 @@ describe("Validation", () => {
             ])).to.eql([
                 {},
                 {},
-                {
-                    value: "No identifier given",
-                },
-                {
-                    value: "No identifier given",
-                },
+                {},
+                {},
                 {},
                 {},
                 {

--- a/src/test/typescript/lib/metadata/Metadata.spec.ts
+++ b/src/test/typescript/lib/metadata/Metadata.spec.ts
@@ -72,6 +72,7 @@ describe("Metadata", () => {
         const deconverted = metadataDeconverter(converted, dropdownLists, true)
 
         expect(deconverted).to.eql(input)
+        expect(metadataDeconverter(metadataConverter(deconverted, dropdownLists), dropdownLists, true)).to.eql(deconverted)
     })
 
     it("should return the same object when doing a convert and deconvert consecutively for mandatoryOnly example on submit", () => {
@@ -81,7 +82,11 @@ describe("Metadata", () => {
 
         expect(deconverted).to.eql({
             ...input,
-            relations: [{ qualifier: "dcterms:relation" }],
+            alternativeIdentifiers: [{ "scheme": "id-type:DOI" }],
+            relations: [
+                { qualifier: "dcterms:relation", "scheme": "id-type:DOI" }, // coming from related identifier
+                { qualifier: "dcterms:relation" }, // coming from relation
+            ],
             dates: [
                 ...input.dates || [],
                 {
@@ -93,6 +98,7 @@ describe("Metadata", () => {
                 },
             ],
         })
+        expect(metadataDeconverter(metadataConverter(deconverted, dropdownLists), dropdownLists, true)).to.eql(deconverted)
     })
 
     it("should return the same object when doing a convert and deconvert consecutively for newMetadata example on submit", () => {
@@ -123,8 +129,13 @@ describe("Metadata", () => {
                     qualifier: "dcterms:date",
                 },
             ],
-            relations: [{ qualifier: "dcterms:relation" }],
+            alternativeIdentifiers: [{ "scheme": "id-type:DOI" }],
+            relations: [
+                { qualifier: "dcterms:relation", "scheme": "id-type:DOI" }, // coming from related identifier
+                { qualifier: "dcterms:relation" }, // coming from relation
+            ],
         })
+        expect(metadataDeconverter(metadataConverter(deconverted, dropdownLists), dropdownLists, true)).to.eql(deconverted)
     })
 
     it("should return the same object when doing a convert and deconvert consecutively for allfields example on save", () => {
@@ -133,6 +144,7 @@ describe("Metadata", () => {
         const deconverted = metadataDeconverter(converted, dropdownLists, false)
 
         expect(deconverted).to.eql(input)
+        expect(metadataDeconverter(metadataConverter(deconverted, dropdownLists), dropdownLists, false)).to.eql(deconverted)
     })
 
     it("should return the same object when doing a convert and deconvert consecutively for mandatoryOnly example on save", () => {
@@ -142,7 +154,11 @@ describe("Metadata", () => {
 
         expect(deconverted).to.eql({
             ...input,
-            relations: [{ qualifier: "dcterms:relation" }],
+            alternativeIdentifiers: [{ "scheme": "id-type:DOI" }],
+            relations: [
+                { qualifier: "dcterms:relation", "scheme": "id-type:DOI" }, // coming from related identifier
+                { qualifier: "dcterms:relation" }, // coming from relation
+            ],
             dates: [
                 ...input.dates || [],
                 {
@@ -154,6 +170,7 @@ describe("Metadata", () => {
                 },
             ],
         })
+        expect(metadataDeconverter(metadataConverter(deconverted, dropdownLists), dropdownLists, false)).to.eql(deconverted)
     })
 
     it("should return the same object when doing a convert and deconvert consecutively for newMetadata example on save", () => {
@@ -162,7 +179,11 @@ describe("Metadata", () => {
         const deconverted = metadataDeconverter(converted, dropdownLists, false)
 
         expect(deconverted).to.eql({
-            relations: [{ qualifier: "dcterms:relation" }],
+            alternativeIdentifiers: [{ "scheme": "id-type:DOI" }],
+            relations: [
+                { qualifier: "dcterms:relation", "scheme": "id-type:DOI" }, // coming from related identifier
+                { qualifier: "dcterms:relation" }, // coming from relation
+            ],
             dates: [
                 {
                     qualifier: "dcterms:date",
@@ -175,5 +196,6 @@ describe("Metadata", () => {
             accessRights: "OPEN_ACCESS",
             ...input,
         })
+        expect(metadataDeconverter(metadataConverter(deconverted, dropdownLists), dropdownLists, false)).to.eql(deconverted)
     })
 })


### PR DESCRIPTION
Fixes EASY-2582

#### When applied it will
* add support for 'other' related/alternative identifiers

@DANS-KNAW/easy for review

**In the form:**
![image](https://user-images.githubusercontent.com/5938204/74220736-a71ef380-4cb0-11ea-8c7c-c72e1859941d.png)

**In DDM:**
```xml
<ddm:references scheme="id-type:DOI" href="https://doi.org/10.17026/test-doi-related-identifier">10.17026/test-doi-related-identifier</ddm:references>
<ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/urn:nbn:nl:ui:test-urn-related-identifier">
  urn:nbn:nl:ui:test-urn-related-identifier
</ddm:replaces>
<dcterms:requires xsi:type="id-type:ISBN">my-isbn-related-identifier</dcterms:requires>
<dcterms:hasVersion xsi:type="id-type:ISSN">my-issn-related-identifier</dcterms:hasVersion>
<dcterms:isFormatOf xsi:type="id-type:NWO-PROJECTNR">my-nwo-related-identifier</dcterms:isFormatOf>
<dcterms:isPartOf>my own related identifier</dcterms:isPartOf>
<ddm:relation xml:lang="eng" href="https://www.google.com">Google</ddm:relation>
<ddm:isFormatOf scheme="id-type:DOI" href="https://doi.org/10.17026/test-doi-alternative-identifier">10.17026/test-doi-alternative-identifier</ddm:isFormatOf>
<ddm:isFormatOf scheme="id-type:URN" href="http://persistent-identifier.nl/urn:nbn:nl:ui:test-urn-alternative-identifier">
  urn:nbn:nl:ui:test-urn-alternative-identifier
</ddm:isFormatOf>
<dcterms:isFormatOf xsi:type="id-type:ISBN">my-isbn-alternative-identifier</dcterms:isFormatOf>
<dcterms:isFormatOf xsi:type="id-type:ISSN">my-issn-alternative-identifier</dcterms:isFormatOf>
<dcterms:isFormatOf xsi:type="id-type:NWO-PROJECTNR">my-nwo-alternative-identifier</dcterms:isFormatOf>
<dcterms:isFormatOf>my own alternative identifier</dcterms:isFormatOf>
```

