### PR TITLE
EASY-2641: ISNI regexp allowed too many digits if the last is X

### DIFF
--- a/src/main/typescript/lib/metadata/Contributor.ts
+++ b/src/main/typescript/lib/metadata/Contributor.ts
@@ -76,7 +76,8 @@ export const ISNI: ContributorIdDropdownListEntry = {
     key: "id-type:ISNI",
     value: "ISNI",
     displayValue: "ISNI",
-    format: "(^(http://isni.org/isni/|ISNI:)[0-9]{15,16}X?$)|(^([0-9]{4}[ ]?){3}[0-9]{3}[0-9xX]$)",
+    // the regexp of the dcx-dai.xsd is embedded in "^()$" to make it a full match in this context
+    format: "^((http://isni.org/isni/[0-9]{15}[0-9X])|((ISNI:? ?)?([0-9]{4} ?){3}[0-9]{3}[0-9X]))$",
     placeholder: "(e.g.: 000000012281955X)",
     replace: [
         {


### PR DESCRIPTION
Fixes EASY-2641: ISNI regexp allowed too many digits if last was X

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* with the old ui: try to submit a new deposit with `http://isni.org/isni/00000001210326839X`
* it will fail and highlight the ISNI, remove the `9` and the highlight disappears
* build, deploy, refresh
* you now will have to remove `39` to make the highlight disappear

#### Related pull requests on github
When released before https://github.com/DANS-KNAW/easy-schema/pull/80
a normal ui/ingest cycle can no longer test that validate-dans-bag rejects a too long ISNI

#### Before merging
* [x] await release https://github.com/DANS-KNAW/easy-schema/pull/80
* [x] merge/deploy together with `easy-validate-dans-bag`