### PR TITLE
EASY-2665: Add smaller examples to contributor helptext

### DIFF
--- a/src/main/resources/helptexts/contributors.html
+++ b/src/main/resources/helptexts/contributors.html
@@ -19,11 +19,41 @@
     </thead>
     <tbody>
     <tr>
+        <td>Initials<span class="mandatory">*</span></td>
+        <td>K.L.</td>
+    </tr>
+    <tr>
+        <td>Surname<span class="mandatory">*</span></td>
+        <td>Houtkamp</td>
+    </tr>
+    <tr>
+        <td>Role</td>
+        <td>Project leader</td>
+    </tr>
+    <tr>
+        <td>ISNI</td>
+        <td>0000 0001 2233 4567</td>
+    </tr>
+    <tr>
+        <td colspan="2">&nbsp;</td>
+    </tr>
+    <tr>
+        <td>Role</td>
+        <td>Data Curator</td>
+    </tr>
+    <tr>
+        <td>Organisation<span class="mandatory">*</span></td>
+        <td>Universiteit Leiden</td>
+    </tr>
+    <tr>
+        <td colspan="2">&nbsp;</td>
+    </tr>
+    <tr>
         <td>(Academic) Title(s)</td>
         <td>dr.</td>
     </tr>
     <tr>
-        <td>Initials</td>
+        <td>Initials<span class="mandatory">*</span></td>
         <td>H.</td>
     </tr>
     <tr>
@@ -31,7 +61,7 @@
         <td>van</td>
     </tr>
     <tr>
-        <td>Surname</td>
+        <td>Surname<span class="mandatory">*</span></td>
         <td>Kampen</td>
     </tr>
     <tr>
@@ -39,11 +69,11 @@
         <td>Project leader</td>
     <tr>
         <td>DAI</td>
-        <td>info:eu-repo/dai/nl/087263149</td>
+        <td>info:eu-repo/dai/nl/087623149</td>
     </tr>
     <tr>
         <td>ORCID</td>
-        <td>0000-0001-2233-4567</td>
+        <td>0000-0002-2879-322X</td>
     </tr>
     <tr>
         <td>ISNI</td>

--- a/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
+++ b/src/main/typescript/lib/formComponents/ContributorFieldArray.tsx
@@ -69,7 +69,7 @@ const ContributorField = ({ names, roleValues, className }: ContributorFieldProp
                        component={TextField}/>
             </div>
             <div className="col form-group col-md-3 mb-1">
-                <label>Initials<Mandatory/></label>
+                <label>Initials</label>
                 <Field name={names[1]}
                        placeholder="initials"
                        component={ErrorHandlingTextField}/>
@@ -81,7 +81,7 @@ const ContributorField = ({ names, roleValues, className }: ContributorFieldProp
                        component={TextField}/>
             </div>
             <div className="col form-group col-md-3 mb-1">
-                <label>Surname<Mandatory/></label>
+                <label>Surname</label>
                 <Field name={names[3]}
                        placeholder="surname"
                        component={ErrorHandlingTextField}/>


### PR DESCRIPTION
Fixes EASY-2665

#### When applied it will
* Remove mandatory-indicators from initials and surname
* Add smaller examples to contributor helptext

#### Where should the reviewer @DANS-KNAW/easy start?

