### PR TITLE
EASY-2619 + EASY-2513: large tar, error handling

### DIFF
--- a/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
@@ -71,7 +71,7 @@ const FileUploader = ({ depositId, depositState }: FileUploaderProps) => {
 
     const uploadFailed = (file: File) => (msg?: string) => {
         setUploadingFile(undefined)
-        setErrorMessage(`An error occurred while uploading ${file.name}${msg ? `: ${msg}` : ""}`)
+        setErrorMessage(`An error occurred while uploading ${file.name.replace(/</g,"&lt;").replace(/>/g,"&gt;")}${msg ? `: ${msg}` : ""}`)
         dispatch(setFileUploadInProgress(false))
     }
 

--- a/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
+++ b/src/main/typescript/components/form/parts/fileUpload/upload/FileUploader.tsx
@@ -75,9 +75,11 @@ const FileUploader = ({ depositId, depositState }: FileUploaderProps) => {
         dispatch(setFileUploadInProgress(false))
     }
 
-    const renderUploadError = () => (
+    const renderUploadError = (message: string) => (
         <div className="col col-12">
-            <Alert>{errorMessage}</Alert>
+            <Alert>
+                <span dangerouslySetInnerHTML={{ __html: message }}/>
+            </Alert>
         </div>
     )
 
@@ -116,7 +118,7 @@ const FileUploader = ({ depositId, depositState }: FileUploaderProps) => {
     return (
         <>
             <div id="upload-error-row" className="row">
-                {errorMessage && renderUploadError()}
+                {errorMessage && renderUploadError(errorMessage)}
             </div>
             <div id="upload-row" className="row">
                 {renderUploadButton()}


### PR DESCRIPTION
Fixes EASY-2619 + EASY-2513: large tar, error handling

#### When applied it will
* render upload error messages as HTML
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

See related pull request

#### Related pull requests on github
required by https://github.com/DANS-KNAW/easy-deposit-api/pull/213
