### PR TITLE
EASY-2685: add non-blank checks before validating person identifiers

### DIFF
--- a/src/main/typescript/components/form/Validation.tsx
+++ b/src/main/typescript/components/form/Validation.tsx
@@ -146,13 +146,13 @@ export const validateContributors: (contributors: Contributor[]) => Contributor[
                     contribError.surname = "No surname given"
             }
 
-            if (contributor.dai && (!contributor.dai.match(DAI.format) || !isDaiValid(contributor.dai)))
+            if (nonEmptyDai && contributor.dai && (!contributor.dai.match(DAI.format) || !isDaiValid(contributor.dai)))
                 contribError.dai = `Invalid ${DAI.displayValue} identifier ${DAI.placeholder}`
 
-            if (contributor.isni && !contributor.isni.match(ISNI.format))
+            if (nonEmptyIsni && contributor.isni && !contributor.isni.match(ISNI.format))
                 contribError.isni = `Invalid ${ISNI.displayValue} identifier ${ISNI.placeholder}`
 
-            if (contributor.orcid && !contributor.orcid.match(ORCID.format))
+            if (nonEmptyOrcid && contributor.orcid && !contributor.orcid.match(ORCID.format))
                 contribError.orcid = `Invalid ${ORCID.displayValue} identifier ${ORCID.placeholder}`
         }
 

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -288,6 +288,12 @@ describe("Validation", () => {
             orcid: "invalid-orcid",
             dai: "123456789",
         }
+        const contributor6: Contributor = {
+            ...contributor1,
+            orcid: " ",
+            isni: " ",
+            dai: " ",
+        }
 
         it("should return an empty array when an empty list is provided", () => {
             expect(validateContributors([])).to.eql([])
@@ -311,6 +317,10 @@ describe("Validation", () => {
 
         it("should return an empty object when an empty object is given", () => {
             expect(validateContributors([contributor4])).to.eql([{}])
+        })
+
+        it("should return an empty object when blank identifiers are provided", () => {
+            expect(validateContributors([contributor6])).to.eql([{}])
         })
 
         it("should return an error object with only field 'surname' when only 'initials' is provided", () => {

--- a/src/test/typescript/component/form/Validation.spec.ts
+++ b/src/test/typescript/component/form/Validation.spec.ts
@@ -274,25 +274,12 @@ describe("Validation", () => {
     })
 
     describe("validateContributors", () => {
-        const contributor1: Contributor = {
+        const mandatoryFieldsContributor: Contributor = {
             initials: "D.A.",
             surname: "N.S.",
         }
-        const contributor2: Contributor = {
+        const organizationContributor: Contributor = {
             organization: "K.N.A.W.",
-        }
-        const contributor3: Contributor = emptyContributor
-        const contributor4: Contributor = {}
-        const contributor5: Contributor = {
-            ...contributor1,
-            orcid: "invalid-orcid",
-            dai: "123456789",
-        }
-        const contributor6: Contributor = {
-            ...contributor1,
-            orcid: " ",
-            isni: " ",
-            dai: " ",
         }
 
         it("should return an empty array when an empty list is provided", () => {
@@ -300,27 +287,32 @@ describe("Validation", () => {
         })
 
         it("should return empty objects when for each Contributor at least 'initials' and 'surname' are provided", () => {
-            expect(validateContributors([contributor1, contributor1])).to.eql([{}, {}])
+            expect(validateContributors([mandatoryFieldsContributor, mandatoryFieldsContributor])).to.eql([{}, {}])
         })
 
         it("should return empty objects when for each Contributor at least the 'organization' is provided", () => {
-            expect(validateContributors([contributor2, contributor2])).to.eql([{}, {}])
+            expect(validateContributors([organizationContributor, organizationContributor])).to.eql([{}, {}])
         })
 
         it("should return empty objects when for each Contributor at least either 'initials' and 'surname' or 'organization' are/is provided", () => {
-            expect(validateContributors([contributor1, contributor2])).to.eql([{}, {}])
+            expect(validateContributors([mandatoryFieldsContributor, organizationContributor])).to.eql([{}, {}])
         })
 
         it("should return an empty object when the contributor is completely empty", () => {
-            expect(validateContributors([contributor3])).to.eql([{}])
+            expect(validateContributors([emptyContributor])).to.eql([{}])
         })
 
         it("should return an empty object when an empty object is given", () => {
-            expect(validateContributors([contributor4])).to.eql([{}])
+            expect(validateContributors([{}])).to.eql([{}])
         })
 
         it("should return an empty object when blank identifiers are provided", () => {
-            expect(validateContributors([contributor6])).to.eql([{}])
+            expect(validateContributors([{
+                ...mandatoryFieldsContributor,
+                orcid: " ",
+                isni: " ",
+                dai: " ",
+            }])).to.eql([{}])
         })
 
         it("should return an error object with only field 'surname' when only 'initials' is provided", () => {
@@ -344,7 +336,11 @@ describe("Validation", () => {
         })
 
         it("should return an error object when for any id, only the scheme or value is given", () => {
-            expect(validateContributors([contributor5])).to.eql([{
+            expect(validateContributors([{
+                ...mandatoryFieldsContributor,
+                orcid: "invalid-orcid",
+                dai: "123456789",
+            }])).to.eql([{
                 orcid: "Invalid ORCID identifier (e.g.: 0000-0002-1825-0097)",
             }])
         })


### PR DESCRIPTION
Fixes EASY-2685

#### When applied it will
* add non-blank checks before validating person identifiers

@DANS-KNAW/easy for review