### PR TITLE
freshdesk ticket 6418 - replace telephone number on the easy home page

### DIFF
--- a/src/main/typescript/components/Footer.tsx
+++ b/src/main/typescript/components/Footer.tsx
@@ -27,7 +27,7 @@ const nwo = require("../../resources/img/footer/logo_NWO.png")
 const ContactColumn = () => (
     <ul className="contact">
         <li>
-            <a href="tel:+31-703494450">+31 70 349 44 50</a>
+            <a href="tel:+31-880034666">+31 88 003 46 66</a>
         </li>
         <li>
             <a href="mailto:info@dans.knaw.nl">info@dans.knaw.nl</a>


### PR DESCRIPTION
Fixes EASY-
Freshdesk ticket 6418 - replace telephone number on the easy home page Footer

#### When applied it will
* Show new telephone number on the easy home page footer +31 88 003 46 66
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
